### PR TITLE
Start stop mode + range/depth image

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,14 @@ project(laser_assembler)
 ##############################################################################
 
 set(THIS_PACKAGE_ROS_DEPS
-tf sensor_msgs message_filters roscpp laser_geometry filters cv_bridge)
+  cv_bridge
+  filters 
+  laser_geometry 
+  message_filters 
+  roscpp 
+  sensor_msgs 
+  tf 
+)
 
 find_package(catkin REQUIRED COMPONENTS
   ${THIS_PACKAGE_ROS_DEPS}
@@ -18,10 +25,11 @@ include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 # Build service definitions
 ##############################################################################
 add_service_files(FILES
-AssembleScans.srv
-AssembleScans2.srv
-StartCollection.srv
-StopCollectionAndAssembleScans2.srv)
+  AssembleScans.srv
+  AssembleScans2.srv
+  StartCollection.srv
+  StopCollectionAndAssembleScans2.srv
+)
 
 generate_messages(DEPENDENCIES sensor_msgs std_msgs)
 
@@ -90,11 +98,11 @@ endif()
 ##############################################################################
 
 install(TARGETS
-    laser_scan_assembler_srv
     laser_scan_assembler
+    laser_scan_assembler_srv
     merge_clouds
-    point_cloud_assembler_srv
     point_cloud_assembler
+    point_cloud_assembler_srv
     point_cloud2_assembler
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,17 +7,19 @@ project(laser_assembler)
 
 set(THIS_PACKAGE_ROS_DEPS
   cv_bridge
-  filters 
-  laser_geometry 
-  message_filters 
-  roscpp 
-  sensor_msgs 
-  tf 
+  filters
+  laser_geometry
+  message_filters
+  message_generation
+  message_runtime
+  roscpp
+  sensor_msgs
+  std_msgs
+  tf
 )
 
 find_package(catkin REQUIRED COMPONENTS
-  ${THIS_PACKAGE_ROS_DEPS}
-  message_generation)
+  ${THIS_PACKAGE_ROS_DEPS})
 find_package(Boost REQUIRED COMPONENTS system)
 include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
@@ -39,7 +41,7 @@ generate_messages(DEPENDENCIES sensor_msgs std_msgs)
 
 catkin_package(
   INCLUDE_DIRS include
-  CATKIN_DEPENDS ${THIS_PACKAGE_ROS_DEPS} message_runtime
+  CATKIN_DEPENDS ${THIS_PACKAGE_ROS_DEPS}
   DEPENDS
   )
 
@@ -76,21 +78,21 @@ add_dependencies(point_cloud2_assembler ${PROJECT_NAME}_gencpp)
 ## unit testing
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(rostest)
-
-  add_executable(periodic_snapshotter examples/periodic_snapshotter.cpp)
-  target_link_libraries(periodic_snapshotter ${catkin_LIBRARIES} ${Boost_LIBRARIES})
-  add_dependencies(periodic_snapshotter ${PROJECT_NAME}_gencpp)
+  find_package(rostest REQUIRED)
 
   add_executable(dummy_scan_producer test/dummy_scan_producer.cpp)
   target_link_libraries(dummy_scan_producer ${catkin_LIBRARIES} ${Boost_LIBRARIES})
   add_dependencies(dummy_scan_producer ${PROJECT_NAME}_gencpp)
 
+  add_executable(periodic_snapshotter examples/periodic_snapshotter.cpp)
+  target_link_libraries(periodic_snapshotter ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+  add_dependencies(periodic_snapshotter ${PROJECT_NAME}_gencpp)
+
   add_executable(test_assembler test/test_assembler.cpp)
   target_link_libraries(test_assembler ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${GTEST_LIBRARIES})
   add_dependencies(test_assembler ${PROJECT_NAME}_gencpp)
 
-  add_rostest(test/test_laser_assembler.launch)
+  add_rostest(test/test_${PROJECT_NAME}.launch)
 endif()
 
 ##############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(laser_assembler)
 ##############################################################################
 
 set(THIS_PACKAGE_ROS_DEPS
-tf sensor_msgs message_filters roscpp laser_geometry filters)
+tf sensor_msgs message_filters roscpp laser_geometry filters cv_bridge)
 
 find_package(catkin REQUIRED COMPONENTS
   ${THIS_PACKAGE_ROS_DEPS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,9 @@ include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 ##############################################################################
 add_service_files(FILES
 AssembleScans.srv
-AssembleScans2.srv)
+AssembleScans2.srv
+StartCollection.srv
+StopCollectionAndAssembleScans2.srv)
 
 generate_messages(DEPENDENCIES sensor_msgs std_msgs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ catkin_package(
 ##############################################################################
 # Build
 ##############################################################################
+link_directories(${PCL_LIBRARY_DIRS})
+add_definitions(${PCL_DEFINITIONS})
 
 add_executable(laser_scan_assembler_srv src/laser_scan_assembler_srv.cpp)
 target_link_libraries(laser_scan_assembler_srv ${catkin_LIBRARIES} ${Boost_LIBRARIES})

--- a/examples/moving_laser_assembler.py
+++ b/examples/moving_laser_assembler.py
@@ -76,20 +76,6 @@ if __name__ == "__main__":
         help="How many pixels in vertical axis of image",
         default=200,
     )
-    parser.add_argument(
-        "--min_range",
-        "--min-range",
-        type=float,
-        help="What is the minimum distance in the range image",
-        default=0,
-    )
-    parser.add_argument(
-        "--max_range",
-        "--max-range",
-        type=float,
-        help="What is the maximum distance in the range image",
-        default=10,
-    )
     args = parser.parse_args(rospy.myargv()[1:])
     print(args)
 
@@ -176,8 +162,6 @@ if __name__ == "__main__":
         max_width=args.max_width,
         vertical_resolution=args.vertical_resolution,
         horizontal_resolution=args.horizontal_resolution,
-        min_range=args.min_range,
-        max_range=args.max_range,
     )
     # Wait for a result for the total movement time + some margin
     fjta.send_goal_and_wait(

--- a/examples/moving_laser_assembler.py
+++ b/examples/moving_laser_assembler.py
@@ -28,40 +28,64 @@ if __name__ == "__main__":
         description="Control the fork and laser assembler in unison"
     )
     parser.add_argument(
-        "--scan_start", type=float, help="Height to start scan at", default=0.1
+        "--scan_start",
+        "--scan-start",
+        type=float,
+        help="Height to start scan at",
+        default=0.1,
     )
     parser.add_argument(
-        "--scan_end", type=float, help="Height to end scan at", default=2.0
+        "--scan_end",
+        "--scan-end",
+        type=float,
+        help="Height to end scan at",
+        default=2.0,
     )
     parser.add_argument(
-        "--velocity", type=float, help="Velocity to move the joint with", default=0.5
+        "--velocity",
+        "--velocity",
+        type=float,
+        help="Velocity to move the joint with",
+        default=0.5,
     )
     parser.add_argument(
-        "--min_width", type=float, help="Left end of the FoV", default=-pi
+        "--min_width",
+        "--min-width",
+        type=float,
+        help="Left end of the FoV",
+        default=-pi,
     )
     parser.add_argument(
-        "--max_width", type=float, help="Right end of the FoV", default=pi
+        "--max_width",
+        "--max-width",
+        type=float,
+        help="Right end of the FoV",
+        default=pi,
     )
     parser.add_argument(
         "--vertical_resolution",
+        "--vertical-resolution",
         type=int,
         help="How many pixels in horizontal axis of image",
         default=200,
     )
     parser.add_argument(
         "--horizontal_resolution",
+        "--horizontal-resolution",
         type=int,
         help="How many pixels in vertical axis of image",
         default=200,
     )
     parser.add_argument(
         "--min_range",
+        "--min-range",
         type=float,
         help="What is the minimum distance in the range image",
         default=0,
     )
     parser.add_argument(
         "--max_range",
+        "--max-range",
         type=float,
         help="What is the maximum distance in the range image",
         default=10,
@@ -72,9 +96,9 @@ if __name__ == "__main__":
     component = "mast_lift"
     joint = "mast_lift_joint"
 
-    scan_start = 0.10
-    scan_end = 2.1
-    joint_velocity = 0.5
+    scan_start = args.scan_start
+    scan_end = args.scan_end
+    joint_velocity = args.velocity
 
     scan_duration = rospy.Duration.from_sec(abs(scan_end - scan_start) / joint_velocity)
 
@@ -148,12 +172,12 @@ if __name__ == "__main__":
     start_srv(
         min_height=scan_start,
         max_height=scan_end,
-        min_width=-pi / 2,
-        max_width=pi / 2,
-        vertical_resolution=200,
-        horizontal_resolution=200,
-        min_range=1.5,
-        max_range=10,
+        min_width=args.min_width,
+        max_width=args.max_width,
+        vertical_resolution=args.vertical_resolution,
+        horizontal_resolution=args.horizontal_resolution,
+        min_range=args.min_range,
+        max_range=args.max_range,
     )
     # Wait for a result for the total movement time + some margin
     fjta.send_goal_and_wait(

--- a/examples/moving_laser_assembler.py
+++ b/examples/moving_laser_assembler.py
@@ -1,0 +1,136 @@
+#! /usr/bin/env python
+
+from actionlib.simple_action_client import SimpleActionClient
+from control_msgs.msg import (
+    FollowJointTrajectoryAction,
+    FollowJointTrajectoryGoal,
+    FollowJointTrajectoryResult,
+)
+from laser_assembler.srv import (
+    StartCollection,
+    StartCollectionRequest,
+    StartCollectionResponse,
+    StopCollectionAndAssembleScans2,
+    StopCollectionAndAssembleScans2Request,
+    StopCollectionAndAssembleScans2Response,
+)
+import rospy
+from sensor_msgs.msg import PointCloud2, JointState
+from std_msgs.msg import Header
+from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
+from math import pi
+
+if __name__ == "__main__":
+    rospy.init_node("assemble_moving_laser")
+
+    component = "mast_lift"
+    joint = "mast_lift_joint"
+
+    scan_start = 0.10
+    scan_end = 2.6
+    joint_velocity = 0.5
+
+    scan_duration = rospy.Duration.from_sec(abs(scan_end - scan_start) / joint_velocity)
+
+    assembled_cloud_pub = rospy.Publisher("assembled_cloud", PointCloud2, queue_size=1)
+
+    fjta = SimpleActionClient(
+        f"/{component}/joint_trajectory_controller/follow_joint_trajectory",
+        FollowJointTrajectoryAction,
+    )
+
+    start_srv = rospy.ServiceProxy("/start_collection", StartCollection)
+    stop_srv = rospy.ServiceProxy("/stop_collection_and_assemble_scans2", StopCollectionAndAssembleScans2)
+
+    rospy.loginfo(f"Waiting for FollowJointTrajectory of {component}")
+    fjta.wait_for_server(rospy.Duration(1))
+    rospy.loginfo(f"Waiting for scan assembler")
+    start_srv.wait_for_service(rospy.Duration(1))
+    stop_srv.wait_for_service(rospy.Duration(1))
+
+    rospy.loginfo(f"Waiting for current state of {component}")
+    current_state = rospy.wait_for_message("/joint_states", JointState)  # type: JointState
+    current_state_dict = dict(zip(current_state.name, current_state.position))
+    rospy.loginfo(f"Current state of {component} is {current_state_dict}")
+
+    joint_initial = current_state_dict[joint]
+    current_to_start_scan_dur = rospy.Duration.from_sec(abs(scan_start - joint_initial) / joint_velocity)
+    end_scan_to_initial_dur = rospy.Duration.from_sec(abs(joint_initial - scan_end) / joint_velocity)
+
+    to_start_traj = JointTrajectory(
+        header=Header(
+            stamp=rospy.Time.now() + rospy.Duration.from_sec(0.1),
+            frame_id="base_footprint",
+        ),
+        joint_names=["mast_lift_joint"],
+        points=[
+            JointTrajectoryPoint(time_from_start=rospy.Duration(0), positions=[joint_initial]),
+            JointTrajectoryPoint(time_from_start=current_to_start_scan_dur, positions=[scan_start]),
+        ],
+    )
+    rospy.loginfo("Move to start of scan")
+    fjta.send_goal_and_wait(FollowJointTrajectoryGoal(trajectory=to_start_traj))
+
+    rospy.loginfo("Starting scan movement")
+
+    scan_traj = JointTrajectory(
+        header=Header(
+            stamp=rospy.Time.now() + rospy.Duration.from_sec(0.1),
+            frame_id="base_footprint",
+        ),
+        joint_names=["mast_lift_joint"],
+        points=[
+            JointTrajectoryPoint(time_from_start=rospy.Duration(0), positions=[scan_start]),
+            JointTrajectoryPoint(time_from_start=scan_duration, positions=[scan_end]),
+        ],
+    )
+    scan_movement_start = rospy.Time.now()
+    start_srv(min_height=scan_start,
+              max_height=scan_end,
+              min_width=-pi/2,
+              max_width=pi/2,
+              vertical_resolution=200,
+              horizontal_resolution=200,
+              depth_resolution=0)
+    # Wait for a result for the total movement time + some margin
+    fjta.send_goal_and_wait(
+        FollowJointTrajectoryGoal(trajectory=scan_traj),
+        execute_timeout=scan_traj.points[-1].time_from_start + rospy.Duration(5),
+    )
+    rospy.loginfo("Scan movement finished, stopping collection of scans")
+    stop_srv()
+
+    move_result = fjta.get_result()
+    scan_movement_end = rospy.Time.now()  # Only really the end if move_result == True!
+
+    rospy.loginfo("Moving back to initial")
+    back_to_initial_traj = JointTrajectory(
+        header=Header(
+            stamp=rospy.Time.now() + rospy.Duration.from_sec(0.1),
+            frame_id="base_footprint",
+        ),
+        joint_names=["mast_lift_joint"],
+        points=[
+            JointTrajectoryPoint(time_from_start=rospy.Duration(0), positions=[scan_end]),
+            JointTrajectoryPoint(time_from_start=end_scan_to_initial_dur, positions=[joint_initial]),
+        ],
+    )
+
+    fjta.send_goal(FollowJointTrajectoryGoal(trajectory=back_to_initial_traj))
+    # if move_result:
+    #     if move_result and move_result.error_code == FollowJointTrajectoryResult.SUCCESSFUL:
+    #         rospy.loginfo("Starting scan assembler")
+    #         assemble_response = assemble_srv(
+    #             begin=scan_movement_start, end=scan_movement_end
+    #         )  # type: AssembleScans2Response
+    #         rospy.loginfo("Got result, will publish")
+    #         rospy.loginfo("Width: {}".format(assemble_response.cloud.width))
+    #         rospy.loginfo("Height: {}".format(assemble_response.cloud.height))
+    #
+    #         assembled_cloud_pub.publish(assemble_response.cloud)
+    #     else:
+    #         rospy.logerr(f"Movement not succeeded: {move_result.error_code}")
+    # else:
+    #     rospy.logerr(f"Movement not yet done: {move_result.error_code}")
+    fjta.wait_for_result()
+    rospy.loginfo("Arrived back at initial state, all movement done")

--- a/examples/moving_laser_assembler.py
+++ b/examples/moving_laser_assembler.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 
+import argparse
 from actionlib.simple_action_client import SimpleActionClient
 from control_msgs.msg import (
     FollowJointTrajectoryAction,
@@ -22,6 +23,51 @@ from math import pi
 
 if __name__ == "__main__":
     rospy.init_node("assemble_moving_laser")
+
+    parser = argparse.ArgumentParser(
+        description="Control the fork and laser assembler in unison"
+    )
+    parser.add_argument(
+        "--scan_start", type=float, help="Height to start scan at", default=0.1
+    )
+    parser.add_argument(
+        "--scan_end", type=float, help="Height to end scan at", default=2.0
+    )
+    parser.add_argument(
+        "--velocity", type=float, help="Velocity to move the joint with", default=0.5
+    )
+    parser.add_argument(
+        "--min_width", type=float, help="Left end of the FoV", default=-pi
+    )
+    parser.add_argument(
+        "--max_width", type=float, help="Right end of the FoV", default=pi
+    )
+    parser.add_argument(
+        "--vertical_resolution",
+        type=int,
+        help="How many pixels in horizontal axis of image",
+        default=200,
+    )
+    parser.add_argument(
+        "--horizontal_resolution",
+        type=int,
+        help="How many pixels in vertical axis of image",
+        default=200,
+    )
+    parser.add_argument(
+        "--min_range",
+        type=float,
+        help="What is the minimum distance in the range image",
+        default=0,
+    )
+    parser.add_argument(
+        "--max_range",
+        type=float,
+        help="What is the maximum distance in the range image",
+        default=10,
+    )
+    args = parser.parse_args(rospy.myargv()[1:])
+    print(args)
 
     component = "mast_lift"
     joint = "mast_lift_joint"

--- a/include/laser_assembler/base_assembler.h
+++ b/include/laser_assembler/base_assembler.h
@@ -103,6 +103,9 @@ protected:
   ros::NodeHandle private_ns_;
   ros::NodeHandle n_;
 
+  //! \brief The frame to transform data into upon receipt
+  std::string fixed_frame_ ;
+
   bool assembleScanIndices(sensor_msgs::PointCloud& cloud, const unsigned int start_index, const unsigned int past_end_index);
 
 private:
@@ -128,9 +131,6 @@ private:
 
   //! \brief The max number of scans to store in the scan history
   unsigned int max_scans_ ;
-
-  //! \brief The frame to transform data into upon receipt
-  std::string fixed_frame_ ;
 
   //! \brief Specify how much to downsample the data. A value of 1 preserves all the data. 3 would keep 1/3 of the data.
   unsigned int downsample_factor_ ;

--- a/include/laser_assembler/base_assembler.h
+++ b/include/laser_assembler/base_assembler.h
@@ -197,13 +197,13 @@ void BaseAssembler<T>::start(const std::string& in_topic_name)
 {
   ROS_DEBUG("Called start(string). Starting to listen on message_filter::Subscriber the input stream");
   if (tf_filter_)
-    ROS_ERROR("assembler::start() was called twice!. This is bad, and could leak memory") ;
+    ROS_WARN("assembler::start() was called twice!. This is bad, and could leak memory if not done right") ;
   else
   {
-    scan_sub_.subscribe(n_, in_topic_name, 10);
     tf_filter_ = new tf::MessageFilter<T>(scan_sub_, *tf_, fixed_frame_, 10);
     tf_filter_->registerCallback( boost::bind(&BaseAssembler<T>::msgCallback, this, boost::placeholders::_1) );
   }
+  scan_sub_.subscribe(n_, in_topic_name, 10);
 }
 
 template <class T>
@@ -211,13 +211,13 @@ void BaseAssembler<T>::start()
 {
   ROS_DEBUG("Called start(). Starting tf::MessageFilter, but not initializing Subscriber");
   if (tf_filter_)
-    ROS_ERROR("assembler::start() was called twice!. This is bad, and could leak memory") ;
+    ROS_WARN("assembler::start() was called twice!. This is bad, and could leak memory if not done right") ;
   else
   {
-    scan_sub_.subscribe(n_, "bogus", 10);
     tf_filter_ = new tf::MessageFilter<T>(scan_sub_, *tf_, fixed_frame_, 10);
     tf_filter_->registerCallback( boost::bind(&BaseAssembler<T>::msgCallback, this, boost::placeholders::_1) );
   }
+  scan_sub_.subscribe(n_, "bogus", 10);
 }
 
 template <class T>

--- a/include/laser_assembler/base_assembler.h
+++ b/include/laser_assembler/base_assembler.h
@@ -281,7 +281,7 @@ bool BaseAssembler<T>::assembleScanIndices(sensor_msgs::PointCloud& cloud, const
     const unsigned int num_channels = scan_hist_[start_index].channels.size ();
     cloud.channels.resize (num_channels) ;
 
-    ROS_INFO_STREAM_NAMED("assembleScans", "Cloud will have " << req_pts << " points and " << num_channels << " channels");
+    ROS_DEBUG_STREAM_NAMED("assembleScanIndices", "Cloud will have " << req_pts << " points and " << num_channels << " channels");
 
     for (unsigned int i = 0; i<num_channels; i++)
     {
@@ -298,7 +298,7 @@ bool BaseAssembler<T>::assembleScanIndices(sensor_msgs::PointCloud& cloud, const
       for (unsigned int chan_ind = 0; chan_ind < scan_hist_[i].channels.size(); chan_ind++)
       {
         if (scan_hist_[i].points.size () != scan_hist_[i].channels[chan_ind].values.size())
-          ROS_FATAL_NAMED("assembleScans", "Trying to add a malformed point cloud. Cloud has %u points, but channel %u has %u elems", (int)scan_hist_[i].points.size (), chan_ind, (int)scan_hist_[i].channels[chan_ind].values.size ());
+          ROS_FATAL_NAMED("assembleScanIndices", "Trying to add a malformed point cloud. Cloud has %u points, but channel %u has %u elems", (int)scan_hist_[i].points.size (), chan_ind, (int)scan_hist_[i].channels[chan_ind].values.size ());
       }
 
       for(unsigned int j=0; j<scan_hist_[i].points.size (); j+=downsample_factor_)
@@ -327,7 +327,7 @@ bool BaseAssembler<T>::buildCloud(AssembleScans::Request& req, AssembleScans::Re
 template <class T>
 bool BaseAssembler<T>::assembleScans(AssembleScans::Request& req, AssembleScans::Response& resp)
 {
-  ROS_INFO_NAMED("assembleScans", "Starting Service Request") ;
+  ROS_DEBUG_NAMED("assembleScans", "Starting Service Request") ;
 
   scan_hist_mutex_.lock() ;
   // Determine where in our history we actually are
@@ -349,11 +349,11 @@ bool BaseAssembler<T>::assembleScans(AssembleScans::Request& req, AssembleScans:
     i += downsample_factor_ ;
   }
   unsigned int past_end_index = i ;
-  ROS_INFO_STREAM_NAMED("assembleScans", "start_index: " << i << ", past_end_index: " << past_end_index << ", downsample_factor_: " << downsample_factor_);
+  ROS_DEBUG_STREAM_NAMED("assembleScans", "start_index: " << i << ", past_end_index: " << past_end_index << ", downsample_factor_: " << downsample_factor_);
 
   if (start_index == past_end_index)
   {
-    ROS_INFO_STREAM_NAMED("assembleScans", "start_index==past_end_index, so no data");
+    ROS_DEBUG_STREAM_NAMED("assembleScans", "start_index==past_end_index, so no data");
     resp.cloud.header.frame_id = fixed_frame_ ;
     resp.cloud.header.stamp = req.end ;
     resp.cloud.points.resize (0) ;
@@ -365,7 +365,7 @@ bool BaseAssembler<T>::assembleScans(AssembleScans::Request& req, AssembleScans:
   }
   scan_hist_mutex_.unlock() ;
 
-  ROS_INFO_NAMED("assembleScans", "Point Cloud Results: Aggregated from index %u->%u. BufferSize: %lu. Points in cloud: %u", start_index, past_end_index, scan_hist_.size(), (int)resp.cloud.points.size ()) ;
+  ROS_DEBUG_NAMED("assembleScans", "Point Cloud Results: Aggregated from index %u->%u. BufferSize: %lu. Points in cloud: %u", start_index, past_end_index, scan_hist_.size(), (int)resp.cloud.points.size ()) ;
   return true ;
 }
 
@@ -391,5 +391,4 @@ bool BaseAssembler<T>::assembleScans2(AssembleScans2::Request& req, AssembleScan
   }
   return ret;
 }
-
 }

--- a/include/laser_assembler/base_assembler.h
+++ b/include/laser_assembler/base_assembler.h
@@ -94,6 +94,7 @@ public:
 protected:
   tf::TransformListener* tf_ ;
   tf::MessageFilter<T>* tf_filter_;
+  message_filters::Subscriber<T> scan_sub_;
 
   ros::NodeHandle private_ns_;
   ros::NodeHandle n_;
@@ -104,7 +105,6 @@ private:
   ros::ServiceServer assemble_scans_server_;
   ros::ServiceServer build_cloud_server2_;
   ros::ServiceServer assemble_scans_server2_;
-  message_filters::Subscriber<T> scan_sub_;
   message_filters::Connection tf_filter_connection_;
 
   //! \brief Callback function for every time we receive a new scan

--- a/include/laser_assembler/base_assembler.h
+++ b/include/laser_assembler/base_assembler.h
@@ -267,45 +267,45 @@ void BaseAssembler<T>::msgCallback(const boost::shared_ptr<const T>& scan_ptr)
 template <class T>
 bool BaseAssembler<T>::assembleScanIndices(sensor_msgs::PointCloud& cloud, const unsigned int start_index, const unsigned int past_end_index, const unsigned int req_pts)
 {
-    // // Note: We are assuming that channel information is consistent across multiple scans. If not, then bad things (segfaulting) will happen
-    // // Allocate space for the cloud
-    // cloud.points.resize (req_pts);
-    // const unsigned int num_channels = scan_hist_[start_index].channels.size ();
-    // cloud.channels.resize (num_channels) ;
+    // Note: We are assuming that channel information is consistent across multiple scans. If not, then bad things (segfaulting) will happen
+    // Allocate space for the cloud
+    cloud.points.resize (req_pts);
+    const unsigned int num_channels = scan_hist_[start_index].channels.size ();
+    cloud.channels.resize (num_channels) ;
 
-    // ROS_INFO_STREAM_NAMED("assembleScans", "Cloud will have " << req_pts << " points and " << num_channels << " channels");
+    ROS_INFO_STREAM_NAMED("assembleScans", "Cloud will have " << req_pts << " points and " << num_channels << " channels");
 
-    // for (unsigned int i = 0; i<num_channels; i++)
-    // {
-    //   cloud.channels[i].name = scan_hist_[start_index].channels[i].name ;
-    //   cloud.channels[i].values.resize (req_pts) ;
-    // }
-    // //cloud.header.stamp = req.end ;
-    // cloud.header.frame_id = fixed_frame_ ;
-    // unsigned int cloud_count = 0 ;
-    // for (i=start_index; i<past_end_index; i+=downsample_factor_)
-    // {
+    for (unsigned int i = 0; i<num_channels; i++)
+    {
+      cloud.channels[i].name = scan_hist_[start_index].channels[i].name ;
+      cloud.channels[i].values.resize (req_pts) ;
+    }
+    //cloud.header.stamp = req.end ;
+    cloud.header.frame_id = fixed_frame_ ;
+    unsigned int cloud_count = 0 ;
+    for (unsigned int i=start_index; i<past_end_index; i+=downsample_factor_)
+    {
 
-    //   // Sanity check: Each channel should be the same length as the points vector
-    //   for (unsigned int chan_ind = 0; chan_ind < scan_hist_[i].channels.size(); chan_ind++)
-    //   {
-    //     if (scan_hist_[i].points.size () != scan_hist_[i].channels[chan_ind].values.size())
-    //       ROS_FATAL_NAMED("assembleScans", "Trying to add a malformed point cloud. Cloud has %u points, but channel %u has %u elems", (int)scan_hist_[i].points.size (), chan_ind, (int)scan_hist_[i].channels[chan_ind].values.size ());
-    //   }
+      // Sanity check: Each channel should be the same length as the points vector
+      for (unsigned int chan_ind = 0; chan_ind < scan_hist_[i].channels.size(); chan_ind++)
+      {
+        if (scan_hist_[i].points.size () != scan_hist_[i].channels[chan_ind].values.size())
+          ROS_FATAL_NAMED("assembleScans", "Trying to add a malformed point cloud. Cloud has %u points, but channel %u has %u elems", (int)scan_hist_[i].points.size (), chan_ind, (int)scan_hist_[i].channels[chan_ind].values.size ());
+      }
 
-    //   for(unsigned int j=0; j<scan_hist_[i].points.size (); j+=downsample_factor_)
-    //   {
-    //     cloud.points[cloud_count].x = scan_hist_[i].points[j].x ;
-    //     cloud.points[cloud_count].y = scan_hist_[i].points[j].y ;
-    //     cloud.points[cloud_count].z = scan_hist_[i].points[j].z ;
+      for(unsigned int j=0; j<scan_hist_[i].points.size (); j+=downsample_factor_)
+      {
+        cloud.points[cloud_count].x = scan_hist_[i].points[j].x ;
+        cloud.points[cloud_count].y = scan_hist_[i].points[j].y ;
+        cloud.points[cloud_count].z = scan_hist_[i].points[j].z ;
 
-    //     for (unsigned int k=0; k<num_channels; k++)
-    //       cloud.channels[k].values[cloud_count] = scan_hist_[i].channels[k].values[j] ;
+        for (unsigned int k=0; k<num_channels; k++)
+          cloud.channels[k].values[cloud_count] = scan_hist_[i].channels[k].values[j] ;
 
-    //     cloud_count++ ;
-    //   }
-    //   cloud.header.stamp = scan_hist_[i].header.stamp;
-    // }
+        cloud_count++ ;
+      }
+      cloud.header.stamp = scan_hist_[i].header.stamp;
+    }
     return true;
 }
 

--- a/include/laser_assembler/base_assembler.h
+++ b/include/laser_assembler/base_assembler.h
@@ -106,6 +106,9 @@ protected:
   //! \brief The frame to transform data into upon receipt
   std::string fixed_frame_ ;
 
+  //! \brief The max number of scans to store in the scan history
+  unsigned int max_scans_ ;
+
   bool assembleScanIndices(sensor_msgs::PointCloud& cloud, const unsigned int start_index, const unsigned int past_end_index);
 
 private:
@@ -128,9 +131,6 @@ private:
 
   //! \brief The number points currently in the scan history
   unsigned int total_pts_ ;
-
-  //! \brief The max number of scans to store in the scan history
-  unsigned int max_scans_ ;
 
   //! \brief Specify how much to downsample the data. A value of 1 preserves all the data. 3 would keep 1/3 of the data.
   unsigned int downsample_factor_ ;

--- a/include/laser_assembler/base_assembler.h
+++ b/include/laser_assembler/base_assembler.h
@@ -96,6 +96,10 @@ protected:
   tf::MessageFilter<T>* tf_filter_;
   message_filters::Subscriber<T> scan_sub_;
 
+  //! \brief Stores history of scans
+  std::deque<sensor_msgs::PointCloud> scan_hist_ ;
+  boost::mutex scan_hist_mutex_ ;
+
   ros::NodeHandle private_ns_;
   ros::NodeHandle n_;
 
@@ -118,10 +122,6 @@ private:
   bool assembleScans(AssembleScans::Request& req, AssembleScans::Response& resp) ;
   bool buildCloud2(AssembleScans2::Request& req, AssembleScans2::Response& resp) ;
   bool assembleScans2(AssembleScans2::Request& req, AssembleScans2::Response& resp) ;
-
-  //! \brief Stores history of scans
-  std::deque<sensor_msgs::PointCloud> scan_hist_ ;
-  boost::mutex scan_hist_mutex_ ;
 
   //! \brief The number points currently in the scan history
   unsigned int total_pts_ ;

--- a/include/laser_assembler/base_assembler.h
+++ b/include/laser_assembler/base_assembler.h
@@ -35,6 +35,7 @@
 //! \author Vijay Pradeep
 
 #include "ros/ros.h"
+#include "ros/console.h"
 #include "tf/transform_listener.h"
 #include "tf/message_filter.h"
 #include "sensor_msgs/PointCloud.h"
@@ -255,7 +256,7 @@ void BaseAssembler<T>::msgCallback(const boost::shared_ptr<const T>& scan_ptr)
   scan_hist_.push_back(cur_cloud) ;                              // Add the newest scan to the back of the deque
   total_pts_ += cur_cloud.points.size () ;                       // Add the new scan to the running total of points
 
-  ROS_DEBUG_NAMED("msgCallback", "Scans: %4u  Points: %10u\n", scan_hist_.size(), total_pts_) ;
+  ROS_DEBUG_STREAM_NAMED("msgCallback", "Scans: " << scan_hist_.size() << " Points: " << total_pts_) ;
 
   scan_hist_mutex_.unlock() ;
   ROS_DEBUG_NAMED("msgCallback", "done with msgCallback");

--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,9 @@
   <build_depend>pluginlib</build_depend>
   <build_depend>cv_bridge</build_depend>
   
+  <run_depend>actionlib</run_depend>
+  <run_depend>control_msgs</run_depend>
+  <run_depend>trajectory_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>message_filters</run_depend>

--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,7 @@
   <build_depend>filters</build_depend>
   <build_depend>laser_geometry</build_depend>
   <build_depend>pluginlib</build_depend>
+  <build_depend>cv_bridge</build_depend>
   
   <run_depend>message_runtime</run_depend>
   <run_depend>sensor_msgs</run_depend>
@@ -33,6 +34,7 @@
   <run_depend>filters</run_depend>
   <run_depend>laser_geometry</run_depend>
   <run_depend>pluginlib</run_depend>
+  <run_depend>cv_bridge</run_depend>
 
   <export>
   </export>

--- a/package.xml
+++ b/package.xml
@@ -15,29 +15,32 @@
   
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
-  <build_depend>message_generation</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>message_filters</build_depend>
-  <build_depend>tf</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>rostest</build_depend>
+  <build_depend>cv_bridge</build_depend>
   <build_depend>filters</build_depend>
   <build_depend>laser_geometry</build_depend>
-  <build_depend>pluginlib</build_depend>
-  <build_depend>cv_bridge</build_depend>
+  <build_depend>message_filters</build_depend>
+  <build_depend>message_generation</build_depend>
+  <build_depend>message_runtime</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>tf</build_depend>
   
   <run_depend>actionlib</run_depend>
   <run_depend>control_msgs</run_depend>
-  <run_depend>trajectory_msgs</run_depend>
-  <run_depend>message_runtime</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>message_filters</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>tf</run_depend>
+  <run_depend>cv_bridge</run_depend>
   <run_depend>filters</run_depend>
   <run_depend>laser_geometry</run_depend>
-  <run_depend>pluginlib</run_depend>
-  <run_depend>cv_bridge</run_depend>
+  <run_depend>message_filters</run_depend>
+  <run_depend>message_generation</run_depend>
+  <run_depend>message_runtime</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>sensor_msgs</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>tf</run_depend>
+  <run_depend>trajectory_msgs</run_depend>
+
+  <test_depend>rostest</test_depend>
 
   <export>
   </export>

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -38,6 +38,7 @@
 #include "laser_assembler/base_assembler.h"
 #include "laser_assembler/AssembleScans2.h"
 #include "laser_assembler/StartCollection.h"
+#include "laser_assembler/StopCollectionAndAssembleScans2.h"
 #include "filters/filter_chain.h"
 
 using namespace laser_geometry;
@@ -65,6 +66,7 @@ public:
     filter_chain_.configure("filters", private_ns_);
 
     start_collection_server_ = n_.advertiseService("start_collection", &LaserScanAssembler::startCollection, this);
+    stop_collection_server_ = n_.advertiseService("stop_collection_and_assemble_scans2", &LaserScanAssembler::stopCollectionAndAssembleScans2, this);
     if (subscribe_directly_)
       subscribe();
 
@@ -140,6 +142,20 @@ public:
     return true;
   }
 
+  bool stopCollectionAndAssembleScans2(StopCollectionAndAssembleScans2::Request& req, StopCollectionAndAssembleScans2::Response& resp)
+  {
+    if (ignore_laser_skew_)
+    {
+      scan_sub_.unsubscribe();
+    }
+    else
+    {
+      skew_scan_sub_.shutdown();
+    }
+    ROS_INFO("Stopped listening to scans");
+    return true;
+  }
+
 private:
   bool ignore_laser_skew_;
   bool subscribe_directly_;
@@ -148,6 +164,7 @@ private:
   ros::Subscriber skew_scan_sub_;
   ros::Duration max_tolerance_;   // The longest tolerance we've needed on a scan so far
   ros::ServiceServer start_collection_server_;
+  ros::ServiceServer stop_collection_server_;
   StartCollection::Request current_req_;
 
   filters::FilterChain<sensor_msgs::LaserScan> filter_chain_;

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -34,6 +34,7 @@
 
 
 #include "laser_geometry/laser_geometry.h"
+#include "sensor_msgs/image_encodings.h"
 #include "sensor_msgs/Image.h"
 #include "sensor_msgs/LaserScan.h"
 #include "laser_assembler/base_assembler.h"
@@ -143,6 +144,16 @@ public:
 
   bool startCollection(StartCollection::Request& req, StartCollection::Response& resp)
   {
+    stretched_range_image_ = sensor_msgs::Image();
+    stretched_range_image_.encoding = sensor_msgs::image_encodings::TYPE_16UC1;
+    stretched_range_image_.width = req.horizontal_resolution;
+    stretched_range_image_.height = req.vertical_resolution;
+    stretched_range_image_.step = stretched_range_image_.width;
+    stretched_range_image_.data.resize(stretched_range_image_.width * stretched_range_image_.height);
+    stretched_range_image_.header.frame_id = fixed_frame_.c_str();
+
+    ROS_INFO_STREAM("Created image to be filled by scans" << stretched_range_image_);
+
     subscribe();
     return true;
   }
@@ -177,6 +188,8 @@ public:
     }
 
     scan_hist_mutex_.unlock();
+
+    stretched_range_image_pub_.publish(stretched_range_image_);
 
     return true;
   }

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -211,13 +211,13 @@ public:
     }
 
     double interpolated_index = index_under + ((query - value_under) / (value_above - value_under));
-        ROS_INFO_STREAM(
-      "query: " << query <<
-      ", index_under: " << index_under <<
-      ", value_under: " << value_under <<
-      ", index_above: " << index_above <<
-      ", value_above: " << value_above <<
-      ", interpolated_index: " << interpolated_index);
+      //   ROS_INFO_STREAM(
+      // "query: " << query <<
+      // ", index_under: " << index_under <<
+      // ", value_under: " << value_under <<
+      // ", index_above: " << index_above <<
+      // ", value_above: " << value_above <<
+      // ", interpolated_index: " << interpolated_index);
     return interpolated_index;
   }
 
@@ -349,31 +349,31 @@ public:
         auto min_value = curr_value > 0 ? std::min(depth_value, curr_value) : depth_value;
         scan_depth_buffer_.at<uint16_t>(scan_index_, depth_column) = min_value;
 
-        ROS_INFO_STREAM_COND(0==0,
-          "i: " << i <<
-          ", height: " << height <<
-          ", range: " << scan_in.ranges[i] <<
-          ", measurement_angle: " << measurement_angle <<
-          ", depth_x_distance: " << depth_x_distance <<
-          ", depth_column: " << depth_column <<
-          ", depth_min_x: " << depth_min_x <<
-          ", depth_horizontal_step: " << depth_horizontal_step <<
-          ", depth: " << depth <<
-          ", depth_value: " << depth_value <<
-          ", curr_value: " << curr_value <<
-          ", min_value: " << min_value <<
-          "");
+        // ROS_INFO_STREAM_COND(0==0,
+        //   "i: " << i <<
+        //   ", height: " << height <<
+        //   ", range: " << scan_in.ranges[i] <<
+        //   ", angle: " << measurement_angle <<
+        //   ", d_x_d: " << depth_x_distance <<
+        //   ", col: " << depth_column <<
+          // ", depth_min_x: " << depth_min_x <<
+          // ", depth_horizontal_step: " << depth_horizontal_step <<
+          // ", depth: " << depth <<
+          // ", depth_value: " << depth_value <<
+          // ", curr_value: " << curr_value <<
+          // ", min_value: " << min_value <<
+          // "");
       }
       else
       {
-        ROS_INFO_STREAM("Not writing to depth_column " << depth_column << ", range=" << scan_in.ranges[i] << ", measurement_angle=" << measurement_angle);
+        // ROS_INFO_STREAM("Not writing to depth_column " << depth_column << ", range=" << scan_in.ranges[i] << ", measurement_angle=" << measurement_angle);
       }
     }
     // ROS_INFO_STREAM("scan_buffer_.at(" << scan_index_ << ", " << 0 << ") = " << scan_buffer_.at<uint16_t>(scan_index_, 0) << ", scan_in.ranges[0] = " << scan_in.ranges[0]);
 
     // std::cout << "After  push_back: scan_buffer_: " << std::endl << scan_buffer_ << std::endl;
     // std::cout << "stretched_depth_mat_: " << std::endl << stretched_depth_mat_ << std::endl;
-    std::cout << "New row at " << scan_index_ <<" (height=" << height << "): " << std::endl << scan_depth_buffer_.row(scan_index_) << std::endl;
+    // std::cout << "New row at " << scan_index_ <<" (height=" << height << "): " << std::endl << scan_depth_buffer_.row(scan_index_) << std::endl;
 
     scan_index_++;
     // ROS_INFO_STREAM("scan_in.ranges.size(): " << scan_in.ranges.size() <<
@@ -540,12 +540,12 @@ public:
 
     // Process depth image
     auto filled_depth_roi = cv::Rect(0, 0, current_req_.horizontal_resolution, scan_index_);
-    ROS_INFO_STREAM("Buffer has size " << scan_range_buffer_.size() << "and the filled region of that has size " << filled_roi);
+    // ROS_INFO_STREAM("Buffer has size " << scan_range_buffer_.size() << "and the filled region of that has size " << filled_roi);
     cv::Mat cropped_depth = cv::Mat(scan_depth_buffer_, filled_depth_roi);
-    ROS_INFO_STREAM("Cropped_depth has size " << cropped_depth.size());
+    // ROS_INFO_STREAM("Cropped_depth has size " << cropped_depth.size());
     cv::Mat sorted_depth = reorderImageRows(cropped_depth, reordering);
-    ROS_INFO_STREAM("sorted_depth has size " << sorted_depth.size());
-    std::cout << "sorted_depth" << std::endl << sorted_depth << std::endl;
+    // ROS_INFO_STREAM("sorted_depth has size " << sorted_depth.size());
+    // std::cout << "sorted_depth" << std::endl << sorted_depth << std::endl;
 
     cvi_range_mat.image = remapped_buffer;
     cvi_range_mat.toImageMsg(stretched_range_image_);
@@ -563,17 +563,17 @@ public:
 
     cv::Mat depth_x_map;
     cv::resize(depth_x_map_row, depth_x_map, cv::Size(current_req_.horizontal_resolution, current_req_.vertical_resolution), cv::INTER_NEAREST);
-    ROS_INFO_STREAM("depth_x_map has size " << depth_x_map.size());
+    // ROS_INFO_STREAM("depth_x_map has size " << depth_x_map.size());
     // std::cout << "depth_x_map" << std::endl << depth_x_map << std::endl;
 
     // Depth can use the same y map, since the ordering of the rows is the same and the output resolution is the same
-    std::cout << "y_map" << std::endl << y_map << std::endl;
+    // std::cout << "y_map" << std::endl << y_map << std::endl;
 
     cv::Mat remapped_depth_buffer = cv::Mat::zeros(current_req_.vertical_resolution, current_req_.horizontal_resolution, CV_16UC1);
     ROS_DEBUG("Apply remapping");
     cv::remap(sorted_depth, remapped_depth_buffer, depth_x_map, y_map, cv::INTER_LINEAR, cv::BORDER_CONSTANT, 0);
-    ROS_INFO_STREAM("remapped_depth_buffer has size " << remapped_depth_buffer.size());
-    std::cout << "remapped_depth_buffer" << std::endl << remapped_depth_buffer << std::endl;
+    // ROS_INFO_STREAM("remapped_depth_buffer has size " << remapped_depth_buffer.size());
+    // std::cout << "remapped_depth_buffer" << std::endl << remapped_depth_buffer << std::endl;
 
     cv_bridge::CvImage cvi_depth_mat;
     cvi_depth_mat.encoding = sensor_msgs::image_encodings::TYPE_16UC1;

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -120,7 +120,7 @@ public:
 
   cv::Mat sortMatRowBy(cv::Mat key, cv::Mat unsorted, std::vector<double>& sorted_keys)
   {
-    ROS_INFO_STREAM("key.size(): " << key.size() << ", unsorted.size(): " << unsorted.size());
+    ROS_DEBUG_STREAM("key.size(): " << key.size() << ", unsorted.size(): " << unsorted.size());
     cv::Mat sorted = cv::Mat(unsorted.size(), unsorted.type());
 
     // A multimap inserts elements in order (per https://stackoverflow.com/questions/1577475/c-sorting-and-keeping-track-of-indexes)
@@ -134,7 +134,7 @@ public:
     for (auto it=mm.begin(); it!=mm.end(); ++it)
     {
       auto sortedIndex = std::distance(mm.begin(), it);
-      ROS_INFO_STREAM("origIndex: " << (*it).second << ", height: " << (*it).first << ", sortedIndex = " << sortedIndex);
+      // ROS_DEBUG_STREAM("origIndex: " << (*it).second << ", height: " << (*it).first << ", sortedIndex = " << sortedIndex);
       unsorted.row((*it).second).copyTo(sorted.row(sortedIndex));
       sorted_keys.push_back((*it).first);
     }
@@ -452,13 +452,12 @@ public:
     cv_bridge::CvImage cvi_range_mat;
     cvi_range_mat.encoding = sensor_msgs::image_encodings::TYPE_16UC1;
     auto filled_roi = cv::Rect(0, 0, max_scan_length_, scan_index_);
-    ROS_INFO_STREAM("Buffer has size " << scan_buffer_.size() << "and the filled region of that has size " << filled_roi);
+    ROS_DEBUG_STREAM("Buffer has size " << scan_buffer_.size() << "and the filled region of that has size " << filled_roi);
     cv::Mat cropped = cv::Mat(scan_buffer_, filled_roi);
     cv::Mat sorted = sortMatRowBy(height_values_, cropped, sorted_heights);
-    ROS_INFO_STREAM("findInterpolatedIndex(sorted_heights, 0.16): " << findInterpolatedIndex(sorted_heights, 0.16));
 
     // Generate y_map for use in cv::remap
-    ROS_INFO("Create y_map_column");
+    ROS_DEBUG("Create y_map_column");
     cv::Mat y_map_column = cv::Mat::zeros(current_req_.vertical_resolution, 1, CV_32FC1);  // We'll stretch it later, as all the values in a row are the same for Y
     auto vertical_step = fabs(current_req_.max_height - current_req_.min_height) / current_req_.vertical_resolution;
     for (size_t y = 0; y < current_req_.vertical_resolution; y++)
@@ -471,7 +470,7 @@ public:
     cv::resize(y_map_column, y_map, cv::Size(current_req_.vertical_resolution, current_req_.horizontal_resolution), cv::INTER_NEAREST);
 
     // Generate x map for use in cv::remap
-    ROS_INFO("Create x_map_row");
+    ROS_DEBUG("Create x_map_row");
     cv::Mat x_map_row = cv::Mat::zeros(1, current_req_.horizontal_resolution, CV_32FC1);  // We'll stretch it later, as all the values in a column are the same for X
     auto horizontal_step = fabs(current_req_.max_width - current_req_.min_width) / current_req_.horizontal_resolution;
     for (size_t x = 0; x < current_req_.horizontal_resolution; x++)
@@ -484,7 +483,7 @@ public:
     cv::resize(x_map_row, x_map, cv::Size(current_req_.vertical_resolution, current_req_.horizontal_resolution), cv::INTER_NEAREST);
 
     cv::Mat remapped_buffer = cv::Mat::zeros(current_req_.vertical_resolution, current_req_.horizontal_resolution, CV_16UC1);
-    ROS_INFO("Apply remapping");
+    ROS_DEBUG("Apply remapping");
     cv::remap(sorted, remapped_buffer, x_map, y_map, cv::INTER_LINEAR);
 
     cvi_range_mat.image = remapped_buffer;

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -75,7 +75,7 @@ public:
     stop_collection_server_ = n_.advertiseService("stop_collection_and_assemble_scans2", &LaserScanAssembler::stopCollectionAndAssembleScans2, this);
     
     pointcloud2_pub_ = n_.advertise<sensor_msgs::PointCloud2>("depth", 1);
-    stretched_range_image_pub_ =  n_.advertise<sensor_msgs::Image> ("depth_image", 1);
+    stretched_range_image_pub_ =  n_.advertise<sensor_msgs::Image> ("range_image", 1);
 
     if (subscribe_directly_)
       subscribe();

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -295,6 +295,9 @@ public:
 
     scan_hist_mutex_.unlock();
 
+    std::cout << "stretched_range_mat_: " << std::endl << stretched_range_mat_ << std::endl;
+    std::cout << "stretched_depth_mat_: " << std::endl << stretched_depth_mat_ << std::endl;
+
     cv_bridge::CvImage cvi_range_mat;
     cvi_range_mat.encoding = sensor_msgs::image_encodings::TYPE_16UC1;
     cvi_range_mat.image = stretched_range_mat_;

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -319,6 +319,10 @@ public:
     stretched_depth_image_.header.frame_id = fixed_frame_.c_str();
     stretched_depth_image_pub_.publish(stretched_depth_image_);
 
+    // No need for theis data anymore, release the memory and make the Mats empty
+    stretched_range_mat_.release();
+    stretched_depth_mat_.release();
+
     return true;
   }
 

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -512,10 +512,11 @@ public:
     {
       auto height_at_pixel = current_req_.min_height + (y*vertical_step);
       auto row_in_buffer = findInterpolatedIndex(sorted_heights, height_at_pixel);
-      y_map_column.at<float>(y, 0) = (float)row_in_buffer;
-      ROS_INFO_STREAM("y: " << y << 
-        ", height_at_pixel: " << height_at_pixel << 
-        ", row_in_buffer:" << (float)row_in_buffer);
+      // current_req_.vertical_resolution - y because we want the pixels with lower height at the bottom of the image of course
+      y_map_column.at<float>(current_req_.vertical_resolution - y, 0) = (float)row_in_buffer;
+      // ROS_INFO_STREAM("y: " << y <<
+      //   ", height_at_pixel: " << height_at_pixel <<
+      //   ", row_in_buffer:" << (float)row_in_buffer);
     }
     cv::Mat y_map;
     cv::resize(y_map_column, y_map, cv::Size(current_req_.horizontal_resolution, current_req_.vertical_resolution), cv::INTER_NEAREST);

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -514,6 +514,7 @@ public:
     ROS_INFO_STREAM("Cropped_depth has size " << cropped_depth.size());
     cv::Mat sorted_depth = reorderImageRows(cropped_depth, reordering);
     ROS_INFO_STREAM("sorted_depth has size " << sorted_depth.size());
+    std::cout << "sorted_depth" << std::endl << sorted_depth << std::endl;
 
     cvi_range_mat.image = remapped_buffer;
     cvi_range_mat.toImageMsg(stretched_range_image_);
@@ -521,9 +522,28 @@ public:
     stretched_range_image_.header.frame_id = fixed_frame_.c_str();
     stretched_range_image_pub_.publish(stretched_range_image_);
 
+    cv::Mat depth_x_map_row = cv::Mat::zeros(1, current_req_.horizontal_resolution, CV_32FC1);  // We'll stretch it later, as all the values in a column are the same for X
+    for (size_t x = 0; x < current_req_.horizontal_resolution; x++)
+    {
+      // Depths are already in the right column, that is done in ScanToImages where the appropriate trigonometry is perfomed
+      x_map_row.at<float>(0, x) = (float)x;
+    }
+    cv::Mat depth_x_map;
+    cv::resize(depth_x_map_row, depth_x_map, cv::Size(current_req_.vertical_resolution, current_req_.horizontal_resolution), cv::INTER_NEAREST);
+    ROS_INFO_STREAM("depth_x_map has size " << depth_x_map.size());
+    std::cout << "depth_x_map" << std::endl << depth_x_map << std::endl;
+
+    // Depth can use the same y map, since the ordering of the rows is the same and the output resolution is the same
+
+    cv::Mat remapped_depth_buffer = cv::Mat::zeros(current_req_.vertical_resolution, current_req_.horizontal_resolution, CV_16UC1);
+    ROS_DEBUG("Apply remapping");
+    cv::remap(sorted_depth, remapped_depth_buffer, depth_x_map, y_map, cv::INTER_LINEAR);
+    ROS_INFO_STREAM("remapped_depth_buffer has size " << remapped_depth_buffer.size());
+    std::cout << "remapped_depth_buffer" << std::endl << remapped_depth_buffer << std::endl;
+
     cv_bridge::CvImage cvi_depth_mat;
     cvi_depth_mat.encoding = sensor_msgs::image_encodings::TYPE_16UC1;
-    cvi_depth_mat.image = sorted_depth;
+    cvi_depth_mat.image = remapped_depth_buffer;
     cvi_depth_mat.toImageMsg(stretched_depth_image_);
     stretched_depth_image_.header.stamp = ros::Time::now();
     stretched_depth_image_.header.frame_id = fixed_frame_.c_str();

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -221,13 +221,10 @@ public:
       projector_.transformLaserScanToPointCloud (fixed_frame_id, scan_filtered_, cloud_out, *tf_, mask);
     }
 
+    // Only do this when startCollection has set these Mat's to a useable value
     if (!stretched_range_mat_.empty() && !stretched_depth_mat_.empty())
     {
       ScanToImages(fixed_frame_id, scan_in);
-    }
-    else
-    {
-      ROS_INFO("No stretched_range_mat_ or stretched_depth_mat_to fill");
     }
 
     return;

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -450,8 +450,6 @@ public:
       ROS_INFO_STREAM_NAMED("stopCollectionAndAssembleScans2", "Could not assemble scans");
     }
 
-    scan_hist_mutex_.unlock();
-
     // std::cout << "stretched_range_mat_: " << std::endl << stretched_range_mat_ << std::endl;
     // std::cout << "stretched_depth_mat_: " << std::endl << stretched_depth_mat_ << std::endl;
 
@@ -511,6 +509,8 @@ public:
     // No need for theis data anymore, release the memory and make the Mats empty
     stretched_range_mat_.release();
     stretched_depth_mat_.release();
+
+    scan_hist_mutex_.unlock();
 
     return true;
   }

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -330,7 +330,11 @@ public:
     // std::cout << "stretched_depth_mat_: " << std::endl << stretched_depth_mat_ << std::endl;
 
     scan_index_++;
-    max_scan_length_ = scan_in.ranges.size();
+    // ROS_INFO_STREAM("scan_in.ranges.size(): " << scan_in.ranges.size() <<
+    //   ", (uint)scan_in.ranges.size()" << (uint)scan_in.ranges.size() <<
+    //   ", max_scan_length_" << max_scan_length_ <<
+    //   ", std::max((uint)scan_in.ranges.size(), max_scan_length_" << std::max((uint)scan_in.ranges.size(), max_scan_length_));
+    max_scan_length_ = std::max((uint)scan_in.ranges.size(), max_scan_length_);
   }
 
   void ConvertToCloud(const string& fixed_frame_id, const sensor_msgs::LaserScan& scan_in, sensor_msgs::PointCloud& cloud_out)
@@ -489,7 +493,7 @@ private:
   cv::Mat scan_buffer_;
   uint scan_index_;
   cv::Mat height_values_;
-  uint max_scan_length_;
+  uint max_scan_length_ = 0;
 
   cv::Mat stretched_range_mat_;
   sensor_msgs::Image stretched_range_image_;

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -211,13 +211,13 @@ public:
     }
 
     double interpolated_index = index_under + ((query - value_under) / (value_above - value_under));
-    //     ROS_INFO_STREAM(
-    //   "query: " << query <<
-    //   ", index_under: " << index_under <<
-    //   ", value_under: " << value_under <<
-    //   ", index_above: " << index_above <<
-    //   ", value_above: " << value_above)<<
-    //   ", interpolated_index: " << interpolated_index);
+        ROS_INFO_STREAM(
+      "query: " << query <<
+      ", index_under: " << index_under <<
+      ", value_under: " << value_under <<
+      ", index_above: " << index_above <<
+      ", value_above: " << value_above <<
+      ", interpolated_index: " << interpolated_index);
     return interpolated_index;
   }
 
@@ -349,26 +349,31 @@ public:
         auto min_value = curr_value > 0 ? std::min(depth_value, curr_value) : depth_value;
         scan_depth_buffer_.at<uint16_t>(scan_index_, depth_column) = min_value;
 
-        // ROS_INFO_STREAM_COND(i==i,
-        //   "i: " << i <<
-        //   ", height: " << height <<
-        //   ", range: " << scan_in.ranges[i] <<
-        //   ", measurement_angle: " << measurement_angle <<
-        //   ", depth_x_distance: " << depth_x_distance <<
-        //   ", depth_column: " << depth_column <<
-        //   ", depth_min_x: " << depth_min_x <<
-        //   ", depth_horizontal_step: " << depth_horizontal_step <<
-        //   ", depth: " << depth <<
-        //   ", depth_value: " << depth_value <<
-        //   ", min_value: " << min_value <<
-        //   "");
+        ROS_INFO_STREAM_COND(0==0,
+          "i: " << i <<
+          ", height: " << height <<
+          ", range: " << scan_in.ranges[i] <<
+          ", measurement_angle: " << measurement_angle <<
+          ", depth_x_distance: " << depth_x_distance <<
+          ", depth_column: " << depth_column <<
+          ", depth_min_x: " << depth_min_x <<
+          ", depth_horizontal_step: " << depth_horizontal_step <<
+          ", depth: " << depth <<
+          ", depth_value: " << depth_value <<
+          ", curr_value: " << curr_value <<
+          ", min_value: " << min_value <<
+          "");
+      }
+      else
+      {
+        ROS_INFO_STREAM("Not writing to depth_column " << depth_column << ", range=" << scan_in.ranges[i] << ", measurement_angle=" << measurement_angle);
       }
     }
     // ROS_INFO_STREAM("scan_buffer_.at(" << scan_index_ << ", " << 0 << ") = " << scan_buffer_.at<uint16_t>(scan_index_, 0) << ", scan_in.ranges[0] = " << scan_in.ranges[0]);
 
     // std::cout << "After  push_back: scan_buffer_: " << std::endl << scan_buffer_ << std::endl;
     // std::cout << "stretched_depth_mat_: " << std::endl << stretched_depth_mat_ << std::endl;
-    std::cout << "New row at " << scan_index_ <<": " << std::endl << scan_depth_buffer_.row(scan_index_) << std::endl;
+    std::cout << "New row at " << scan_index_ <<" (height=" << height << "): " << std::endl << scan_depth_buffer_.row(scan_index_) << std::endl;
 
     scan_index_++;
     // ROS_INFO_STREAM("scan_in.ranges.size(): " << scan_in.ranges.size() <<
@@ -508,10 +513,12 @@ public:
       auto height_at_pixel = current_req_.min_height + (y*vertical_step);
       auto row_in_buffer = findInterpolatedIndex(sorted_heights, height_at_pixel);
       y_map_column.at<float>(y, 0) = (float)row_in_buffer;
+      ROS_INFO_STREAM("y: " << y << 
+        ", height_at_pixel: " << height_at_pixel << 
+        ", row_in_buffer:" << (float)row_in_buffer);
     }
     cv::Mat y_map;
     cv::resize(y_map_column, y_map, cv::Size(current_req_.horizontal_resolution, current_req_.vertical_resolution), cv::INTER_NEAREST);
-    std::cout << "y_map" << std::endl << y_map << std::endl;
 
     // Generate x map for use in cv::remap
     ROS_DEBUG("Create x_map_row");
@@ -551,14 +558,15 @@ public:
       // Depths are already in the right column, that is done in ScanToImages where the appropriate trigonometry is perfomed
       depth_x_map_row.at<float>(0, x) = (float)x;
     }
-    std::cout << "depth_x_map_row" << std::endl << depth_x_map_row << std::endl;
+    // std::cout << "depth_x_map_row" << std::endl << depth_x_map_row << std::endl;
 
     cv::Mat depth_x_map;
     cv::resize(depth_x_map_row, depth_x_map, cv::Size(current_req_.horizontal_resolution, current_req_.vertical_resolution), cv::INTER_NEAREST);
     ROS_INFO_STREAM("depth_x_map has size " << depth_x_map.size());
-    std::cout << "depth_x_map" << std::endl << depth_x_map << std::endl;
+    // std::cout << "depth_x_map" << std::endl << depth_x_map << std::endl;
 
     // Depth can use the same y map, since the ordering of the rows is the same and the output resolution is the same
+    std::cout << "y_map" << std::endl << y_map << std::endl;
 
     cv::Mat remapped_depth_buffer = cv::Mat::zeros(current_req_.vertical_resolution, current_req_.horizontal_resolution, CV_16UC1);
     ROS_DEBUG("Apply remapping");

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -297,16 +297,18 @@ public:
 
     scan_hist_mutex_.unlock();
 
-    cv_bridge::CvImage cvi_mat;
-    cvi_mat.encoding = sensor_msgs::image_encodings::TYPE_16UC1;
-    cvi_mat.image = stretched_range_mat_;
-    cvi_mat.toImageMsg(stretched_range_image_);
+    cv_bridge::CvImage cvi_range_mat;
+    cvi_range_mat.encoding = sensor_msgs::image_encodings::TYPE_16UC1;
+    cvi_range_mat.image = stretched_range_mat_;
+    cvi_range_mat.toImageMsg(stretched_range_image_);
     stretched_range_image_.header.stamp = ros::Time::now();
     stretched_range_image_.header.frame_id = fixed_frame_.c_str();
     stretched_range_image_pub_.publish(stretched_range_image_);
 
-    cvi_mat.image = stretched_depth_mat_;
-    cvi_mat.toImageMsg(stretched_depth_image_);
+    cv_bridge::CvImage cvi_depth_mat;
+    cvi_depth_mat.encoding = sensor_msgs::image_encodings::TYPE_16UC1;
+    cvi_depth_mat.image = stretched_depth_mat_;
+    cvi_depth_mat.toImageMsg(stretched_depth_image_);
     stretched_depth_image_.header.stamp = ros::Time::now();
     stretched_depth_image_.header.frame_id = fixed_frame_.c_str();
     stretched_depth_image_pub_.publish(stretched_depth_image_);

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -184,7 +184,7 @@ public:
         uint range_column = (measurement_angle - current_req_.min_width) / range_horizontal_step;
         uint depth_column = (depth_x_distance - depth_min_x) / depth_horizontal_step;
         // ROS_DEBUG_STREAM("column: " << column << ", index: " << i << ", measurement_angle: " << measurement_angle << ", max_width: " << current_req_.max_width << ", min_width: " << current_req_.min_width << ", horizontal_step: " << horizontal_step);
-        // ROS_INFO_STREAM("i: " << i << ", row: " << row << ", range_column: " << range_column << ", range: " << range << ", depth_column: " << depth_column);
+        ROS_INFO_STREAM_COND(i==i, "i: " << i << ", row: " << row << ", range_column: " << range_column << ", range: " << range << ", depth_column: " << depth_column);
         if (range_column >= 0 && range_column < stretched_range_mat_.cols && row >= 0 && row < stretched_range_mat_.rows)
         {
           if (range < current_req_.min_range)
@@ -209,9 +209,12 @@ public:
         if (depth_column >= 0 && depth_column < stretched_depth_mat_.cols && row >= 0 && row < stretched_depth_mat_.rows)
         {
           auto depth = (range * cos(measurement_angle));
-          auto depth_value = depth / depth_step;
-          ROS_INFO_STREAM_COND(i==271, "scan_in.ranges["<<i<<"] ("<< measurement_angle << " rad): range: " << range << ", depth: " << depth << ", (ushort)depth_value: " << (ushort)depth_value << ", depth_column: " << depth_column);
-          stretched_depth_mat_.at<ushort>(row, depth_column) = std::min((ushort)depth, stretched_depth_mat_.at<ushort>(row, depth_column));
+          if (depth > 0.0) // Negative values are possible if the FoV is more than 180 degrees and the laser measures behind it's center plane
+          {
+            auto depth_value = depth / depth_step;
+            ROS_INFO_STREAM_COND(i==i, "scan_in.ranges["<<i<<"] ("<< measurement_angle << " rad): range: " << range << ", depth: " << depth << ", (ushort)depth_value: " << (ushort)depth_value << ", depth_column: " << depth_column);
+            stretched_depth_mat_.at<ushort>(row, depth_column) = std::min((ushort)depth, stretched_depth_mat_.at<ushort>(row, depth_column));
+          }
         }
         else
         {

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -66,7 +66,7 @@ public:
     // ***** Set Laser Projection Method *****
     private_ns_.param("ignore_laser_skew", ignore_laser_skew_, true);
 
-    // Automatically subscribe to scans or wait for service?
+    // Automatically subscribe to scans or wait for start-service?
     private_ns_.param("subscribe_directly", subscribe_directly_, true);
 
     // configure the filter chain from the parameter server
@@ -141,19 +141,7 @@ public:
 
     return sorted;
   }
-
-  cv::Mat reorderImageRows(cv::Mat unsorted, std::multimap<double, std::size_t> reordering)
-  {
-    cv::Mat sorted = cv::Mat(unsorted.size(), unsorted.type());
-    for (auto it=reordering.begin(); it!=reordering.end(); ++it)
-    {
-      auto sortedIndex = std::distance(reordering.begin(), it);
-      ROS_DEBUG_STREAM("origIndex: " << (*it).second << ", height: " << (*it).first << ", sortedIndex = " << sortedIndex);
-      unsorted.row((*it).second).copyTo(sorted.row(sortedIndex));
-    }
-    return sorted;
-  }
-
+  
   /**
    * @brief Given a sorted array of numbers and a number, return an imaginary index at which the query number would occur
    *

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -338,6 +338,8 @@ public:
     height_values_ = cv::Mat::zeros(1000, 0, CV_64FC1);
 
     subscribe();
+
+    resp.success = true;
     return true;
   }
 
@@ -360,6 +362,7 @@ public:
     else
     {
       ROS_INFO_STREAM_NAMED("stopCollectionAndAssembleScans2", "Could not assemble scans");
+      resp.message = "Could not assemble scans";
     }
 
     std::vector<double> sorted_heights;
@@ -369,6 +372,8 @@ public:
     ROS_DEBUG_STREAM("Buffer has size " << scan_range_buffer_.size() << "and the filled region of that has size " << filled_roi);
     cv::Mat cropped_buffer = cv::Mat(scan_range_buffer_, filled_roi);
     std::multimap<double, std::size_t> reordering;
+    //The cropped buffer needs to be sorted before we can use it: 
+    // the height of the scans might not be monotonically increaseing/decreasing when moving up AND down betwen start and stop
     cv::Mat sorted_ranges = sortMatRowBy(height_values_, cropped_buffer, sorted_heights, reordering);
 
     // Generate y_map for use in cv::remap
@@ -453,7 +458,7 @@ public:
     stretched_depth_image.header.frame_id = fixed_frame_.c_str();
     stretched_depth_image_pub_.publish(stretched_depth_image);
 
-    // No need for theis data anymore, release the memory and make the Mats empty
+    // No need for this data anymore, release the memory and make the Mats empty
     scan_range_buffer_.release();
 
     scan_hist_mutex_.unlock();

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -528,7 +528,7 @@ public:
 
     cv::Mat remapped_buffer = cv::Mat::zeros(current_req_.vertical_resolution, current_req_.horizontal_resolution, CV_16UC1);
     ROS_DEBUG("Apply remapping");
-    cv::remap(sorted, remapped_buffer, x_map, y_map, cv::INTER_LINEAR);
+    cv::remap(sorted, remapped_buffer, x_map, y_map, cv::INTER_LINEAR, cv::BORDER_CONSTANT, 0);
 
     // Process depth image
     auto filled_depth_roi = cv::Rect(0, 0, current_req_.horizontal_resolution, scan_index_);
@@ -562,7 +562,7 @@ public:
 
     cv::Mat remapped_depth_buffer = cv::Mat::zeros(current_req_.vertical_resolution, current_req_.horizontal_resolution, CV_16UC1);
     ROS_DEBUG("Apply remapping");
-    cv::remap(sorted_depth, remapped_depth_buffer, depth_x_map, y_map, cv::INTER_LINEAR);
+    cv::remap(sorted_depth, remapped_depth_buffer, depth_x_map, y_map, cv::INTER_LINEAR, cv::BORDER_CONSTANT, 0);
     ROS_INFO_STREAM("remapped_depth_buffer has size " << remapped_depth_buffer.size());
     std::cout << "remapped_depth_buffer" << std::endl << remapped_depth_buffer << std::endl;
 

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -166,7 +166,10 @@ public:
         {
           auto value = (scan_in.ranges[i] - scan_in.range_min) / depth_step;
           // ROS_DEBUG_STREAM("scan_in.ranges["<<i<<"]: " << scan_in.ranges[i] << ", value: " << value << ", (ushort)value: " << (ushort)value);
-          stretched_range_mat_.at<ushort>(row, column) = (ushort)value;
+          
+          // If a pixel already has a value (which is always, the case, pixels are initialized to max range), 
+          // take the minimum value of the new and current
+          stretched_range_mat_.at<ushort>(row, column) = std::min((ushort)value, stretched_range_mat_.at<ushort>(row, column));
         }
         else
         {

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -100,6 +100,20 @@ public:
     ROS_INFO("Started listening to scans");
   }
 
+  void unsubscribe()
+  {
+    ROS_INFO("Stopping to listen to scans");
+    if (ignore_laser_skew_)
+    {
+      scan_sub_.unsubscribe();
+    }
+    else
+    {
+      skew_scan_sub_.shutdown();
+    }
+    ROS_INFO("Stopped listening to scans");
+  }
+
   unsigned int GetPointsInScan(const sensor_msgs::LaserScan& scan)
   {
     return (scan.ranges.size ());
@@ -180,15 +194,7 @@ public:
 
   bool stopCollectionAndAssembleScans2(StopCollectionAndAssembleScans2::Request& req, StopCollectionAndAssembleScans2::Response& resp)
   {
-    if (ignore_laser_skew_)
-    {
-      scan_sub_.unsubscribe();
-    }
-    else
-    {
-      skew_scan_sub_.shutdown();
-    }
-    ROS_INFO("Stopped listening to scans");
+    unsubscribe();
 
     scan_hist_mutex_.lock();
 

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -161,7 +161,7 @@ public:
   double findInterpolatedIndex(std::vector<double> sorted_array, double query)
   {
     //TODO: Handle cases where the number is outside the range
-    ROS_INFO_STREAM("Looking for " << query);
+    // ROS_INFO_STREAM("Looking for " << query);
 
     // From https://alexsm.com/cpp-closest-lower-bound/
     auto iter_geq = std::lower_bound(
@@ -197,13 +197,15 @@ public:
       index_above = iter_geq - sorted_array.begin()+1;
       value_above = after;
     }
-    ROS_INFO_STREAM(
-      "query: " << query <<
-      ", index_under: " << index_under <<
-      ", value_under: " << value_under <<
-      ", index_above: " << index_above <<
-      ", value_above: " << value_above);
+
     double interpolated_index = index_under + ((query - value_under) / (value_above - value_under));
+    //     ROS_INFO_STREAM(
+    //   "query: " << query <<
+    //   ", index_under: " << index_under <<
+    //   ", value_under: " << value_under <<
+    //   ", index_above: " << index_above <<
+    //   ", value_above: " << value_above)<<
+    //   ", interpolated_index: " << interpolated_index);
     return interpolated_index;
   }
 
@@ -298,7 +300,7 @@ public:
     // New implementation that also does interpolation
     // ROS_INFO_STREAM("Current height: " << height << ", current index: " << scan_index_);
     height_values_.push_back<double>(height);
-    ROS_INFO_STREAM("height_values_.size: " << height_values_.size);
+    // ROS_INFO_STREAM("height_values_.size: " << height_values_.size);
     // std::cout << "Before push_back: scan_buffer_: " << std::endl << scan_buffer_ << std::endl;
 
     // std::vector<uint16_t> converted_ranges(scan_in.ranges.begin(), scan_in.ranges.end());

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -34,6 +34,7 @@
 
 
 #include "laser_geometry/laser_geometry.h"
+#include "sensor_msgs/Image.h"
 #include "sensor_msgs/LaserScan.h"
 #include "laser_assembler/base_assembler.h"
 #include "laser_assembler/AssembleScans2.h"
@@ -68,7 +69,8 @@ public:
     start_collection_server_ = n_.advertiseService("start_collection", &LaserScanAssembler::startCollection, this);
     stop_collection_server_ = n_.advertiseService("stop_collection_and_assemble_scans2", &LaserScanAssembler::stopCollectionAndAssembleScans2, this);
     
-    pointcloud2_pub = n_.advertise<sensor_msgs::PointCloud2>("depth", 1);
+    pointcloud2_pub_ = n_.advertise<sensor_msgs::PointCloud2>("depth", 1);
+    stretched_range_image_pub_ =  n_.advertise<sensor_msgs::Image> ("depth_image", 1);
 
     if (subscribe_directly_)
       subscribe();
@@ -167,7 +169,7 @@ public:
       ROS_INFO_STREAM_NAMED("stopCollectionAndAssembleScans2", "Cloud has " << cloud.points.size() << " points from " << scan_hist_.size() << " scans");
       sensor_msgs::PointCloud2 cloud2;
       sensor_msgs::convertPointCloudToPointCloud2(cloud, cloud2);
-      pointcloud2_pub.publish(cloud2);
+      pointcloud2_pub_.publish(cloud2);
     }
     else
     {
@@ -189,7 +191,10 @@ private:
   ros::ServiceServer start_collection_server_;
   ros::ServiceServer stop_collection_server_;
   StartCollection::Request current_req_;
-  ros::Publisher pointcloud2_pub;
+  ros::Publisher pointcloud2_pub_;
+  ros::Publisher stretched_range_image_pub_;
+
+  sensor_msgs::Image stretched_range_image_;
 
   filters::FilterChain<sensor_msgs::LaserScan> filter_chain_;
   mutable sensor_msgs::LaserScan scan_filtered_;

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -214,7 +214,9 @@ public:
     stretched_range_image_.header.frame_id = fixed_frame_.c_str();
     ROS_WARN_COND(req.horizontal_resolution == 0, "horizontal_resolution is zero");
     ROS_WARN_COND(req.vertical_resolution == 0, "vertical_resolution is zero");
-    stretched_range_mat_ = cv::Mat::zeros(req.vertical_resolution, req.horizontal_resolution, CV_16UC1);
+    // Set uninitialized range to max of the datatype, so that we can take the minimum value of current 
+    // and potentially multiple measurements striking the same pixel
+    stretched_range_mat_ = cv::Mat::ones(req.vertical_resolution, req.horizontal_resolution, CV_16UC1) * std::numeric_limits<ushort>::max(); 
     ROS_DEBUG_STREAM("Created image to be filled by scans:\n" << stretched_range_image_);
 
     subscribe();

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -142,6 +142,71 @@ public:
     return sorted;
   }
 
+  /**
+   * @brief Given a sorted array of numbers and a number, return an imaginary index at which the query number would occur
+   *
+   * This assumes the query is in the range of numbers covered by the sorted_array.
+   * The interpolation is simply linear between the first number smaller than the query and the first number larger than the query
+   * 
+   * For example, let sorted_array be {0, 2, 4, 5} and query = 3.0.
+   * 3 sits exactly halfway between sorted_array[1] (=2) and sorted_array[2] (=4)
+   * Then the interpolated index would be 1.5.
+   * For query = 2.2, the index would be 1.1.
+   * For query = 4.3, the index would be 2.3, etc.
+   *
+   * @param sorted_array the array in which to for where the query number would go
+   * @param query number for which to find an index for
+   * @return double
+   */
+  double findInterpolatedIndex(std::vector<double> sorted_array, double query)
+  {
+    //TODO: Handle cases where the number is outside the range
+    ROS_INFO_STREAM("Looking for " << query);
+
+    // From https://alexsm.com/cpp-closest-lower-bound/
+    auto iter_geq = std::lower_bound(
+        sorted_array.begin(),
+        sorted_array.end(),
+        query
+    );
+
+    if (iter_geq == sorted_array.begin())
+    {
+        return 0;
+    }
+
+    double before = *(iter_geq - 1);
+    double after = *(iter_geq);
+
+    size_t index_under = 0;
+    double value_under = 0;
+    size_t index_above = 0;
+    double value_above = 0;
+
+    if (fabs(query - before) < fabs(query - after))
+    {
+      index_under = iter_geq - sorted_array.begin() - 1;
+      value_under = before;
+      index_above = iter_geq - sorted_array.begin();
+      value_above = after;
+    }
+    else
+    {
+      index_under = iter_geq - sorted_array.begin();
+      value_under = before;
+      index_above = iter_geq - sorted_array.begin()+1;
+      value_above = after;
+    }
+    ROS_INFO_STREAM(
+      "query: " << query <<
+      ", index_under: " << index_under <<
+      ", value_under: " << value_under <<
+      ", index_above: " << index_above <<
+      ", value_above: " << value_above);
+    double interpolated_index = index_under + ((query - value_under) / (value_above - value_under));
+    return interpolated_index;
+  }
+
   unsigned int GetPointsInScan(const sensor_msgs::LaserScan& scan)
   {
     return (scan.ranges.size ());

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -193,6 +193,10 @@ public:
 
   bool startCollection(StartCollection::Request& req, StartCollection::Response& resp)
   {
+    scan_hist_mutex_.lock();
+    scan_hist_.clear();
+    scan_hist_mutex_.unlock();
+
     current_req_ = req;
     stretched_range_image_ = sensor_msgs::Image();
     // stretched_range_image_.encoding = sensor_msgs::image_encodings::TYPE_16UC1;

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -341,7 +341,7 @@ public:
       uint depth_column = (depth_x_distance - depth_min_x) / depth_horizontal_step;
 
       auto depth = scan_in.ranges[i] * cos(measurement_angle);
-      if(depth > 0)
+      if(depth > 0 && depth_column >= 0 && depth_column < scan_depth_buffer_.cols)
       {
         // Can only process positive depth value, cannot look behind us really
         auto depth_value = (uint16_t)(depth * 1000);

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -151,7 +151,8 @@ public:
 
       uint row = stretched_range_mat_.rows - ((height - current_req_.min_height) / vertical_step);  // TODO: check proper types, absolutes and rounding
       ROS_INFO_STREAM("height: " << height << ", max_height: " << current_req_.max_height << ", min_height: " << current_req_.min_height << ", vertical_step: " << vertical_step << ", row: " << row);
-      auto depth_scale = (scan_in.range_max - scan_in.range_min) / std::numeric_limits<short>::max();
+      auto depth_scale = (scan_in.range_max - scan_in.range_min) / std::numeric_limits<ushort>::max();
+      ROS_INFO_STREAM("scan_in.range_max: " << scan_in.range_max << ", scan_in.range_min: " << scan_in.range_min << ", std::numeric_limits<short>::max(): " << std::numeric_limits<ushort>::max() << ", depth_scale: " << depth_scale);
 
       for (size_t i = 0; i < scan_in.ranges.size(); i++)
       {
@@ -159,7 +160,9 @@ public:
         ROS_DEBUG_STREAM("i: " << i << ", row: " << row << ", column: " << column << ", range: " << scan_in.ranges[i]);
         if (column >= 0 && column < stretched_range_mat_.cols && row >= 0 && row < stretched_range_mat_.rows)
         {
-          stretched_range_mat_.at<ushort>(row, column) = (ushort)(scan_in.ranges[i] - scan_in.range_min) / depth_scale;  // TODO: scale according to current_req_.depth_resolution
+          auto value = (scan_in.ranges[i] - scan_in.range_min) / depth_scale;
+          ROS_INFO_STREAM("scan_in.ranges["<<i<<"]: " << scan_in.ranges[i] << ", value: " << value << ", (ushort)value: " << (ushort)value);
+          stretched_range_mat_.at<ushort>(row, column) = (ushort)value;
         }
         else
         {

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -549,7 +549,7 @@ public:
     for (size_t x = 0; x < current_req_.horizontal_resolution; x++)
     {
       // Depths are already in the right column, that is done in ScanToImages where the appropriate trigonometry is perfomed
-      x_map_row.at<float>(0, x) = (float)x;
+      depth_x_map_row.at<float>(0, x) = (float)x;
     }
     std::cout << "depth_x_map_row" << std::endl << depth_x_map_row << std::endl;
 

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -117,6 +117,17 @@ public:
     ROS_INFO("Stopped listening to scans");
   }
 
+  cv::Mat convertRangeToDepthImage(cv::Mat range_image)
+  {
+    /* Project the range data to a plane perpendicular to the optical axis of the scanner and through the scanner's center
+     * X distance over the plane is then $range * cos(angle)$
+     * Depth to the plane is then $range * sin(angle)$
+     *
+     * The image X dimension is dependent on max range & angle, since $X_max = range_max * cos(angle_max)$
+     *
+     */
+  }
+
   unsigned int GetPointsInScan(const sensor_msgs::LaserScan& scan)
   {
     return (scan.ranges.size ());

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -76,6 +76,7 @@ public:
     
     pointcloud2_pub_ = n_.advertise<sensor_msgs::PointCloud2>("depth", 1);
     stretched_range_image_pub_ =  n_.advertise<sensor_msgs::Image> ("range_image", 1);
+    stretched_depth_image_pub_ =  n_.advertise<sensor_msgs::Image> ("depth_image", 1);
 
     if (subscribe_directly_)
       subscribe();
@@ -272,9 +273,13 @@ private:
   StartCollection::Request current_req_;
   ros::Publisher pointcloud2_pub_;
   ros::Publisher stretched_range_image_pub_;
+  ros::Publisher stretched_depth_image_pub_;
 
   cv::Mat stretched_range_mat_;
   sensor_msgs::Image stretched_range_image_;
+
+  cv::Mat stretched_depth_mat_;
+  sensor_msgs::Image stretched_depth_image_;
 
   filters::FilterChain<sensor_msgs::LaserScan> filter_chain_;
   mutable sensor_msgs::LaserScan scan_filtered_;

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -510,7 +510,7 @@ public:
       y_map_column.at<float>(y, 0) = (float)row_in_buffer;
     }
     cv::Mat y_map;
-    cv::resize(y_map_column, y_map, cv::Size(current_req_.vertical_resolution, current_req_.horizontal_resolution), cv::INTER_NEAREST);
+    cv::resize(y_map_column, y_map, cv::Size(current_req_.horizontal_resolution, current_req_.vertical_resolution), cv::INTER_NEAREST);
     std::cout << "y_map" << std::endl << y_map << std::endl;
 
     // Generate x map for use in cv::remap
@@ -524,7 +524,7 @@ public:
       x_map_row.at<float>(0, x) = (float)column_in_buffer;
     }
     cv::Mat x_map;
-    cv::resize(x_map_row, x_map, cv::Size(current_req_.vertical_resolution, current_req_.horizontal_resolution), cv::INTER_NEAREST);
+    cv::resize(x_map_row, x_map, cv::Size(current_req_.horizontal_resolution, current_req_.vertical_resolution), cv::INTER_NEAREST);
 
     cv::Mat remapped_buffer = cv::Mat::zeros(current_req_.vertical_resolution, current_req_.horizontal_resolution, CV_16UC1);
     ROS_DEBUG("Apply remapping");
@@ -554,7 +554,7 @@ public:
     std::cout << "depth_x_map_row" << std::endl << depth_x_map_row << std::endl;
 
     cv::Mat depth_x_map;
-    cv::resize(depth_x_map_row, depth_x_map, cv::Size(current_req_.vertical_resolution, current_req_.horizontal_resolution), cv::INTER_NEAREST);
+    cv::resize(depth_x_map_row, depth_x_map, cv::Size(current_req_.horizontal_resolution, current_req_.vertical_resolution), cv::INTER_NEAREST);
     ROS_INFO_STREAM("depth_x_map has size " << depth_x_map.size());
     std::cout << "depth_x_map" << std::endl << depth_x_map << std::endl;
 

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -210,22 +210,28 @@ public:
     height_values_.push_back(height);
     // std::cout << "Before push_back: scan_buffer_: " << std::endl << scan_buffer_ << std::endl;
 
-    std::vector<uint16_t> converted_ranges(scan_in.ranges.begin(), scan_in.ranges.end());
+    // std::vector<uint16_t> converted_ranges(scan_in.ranges.begin(), scan_in.ranges.end());
 
-    ROS_INFO_STREAM("Initializing current_ranges from converted_ranges");
-    cv::Mat current_ranges = cv::Mat(converted_ranges, true);
-    ROS_INFO_STREAM("current_ranges *= 1000");
-    current_ranges *= 1000;  // From meters to millimeters
-    // std::cout << "current_ranges = " << current_ranges << std::endl;
+    // ROS_INFO_STREAM("Initializing current_ranges from converted_ranges");
+    // cv::Mat current_ranges = cv::Mat(converted_ranges, true);
+    // ROS_INFO_STREAM("current_ranges *= 1000");
+    // current_ranges *= 1000;  // From meters to millimeters
+    // // std::cout << "current_ranges = " << current_ranges << std::endl;
 
-    auto roi = cv::Rect(scan_index_, 0, scan_in.ranges.size(), 1);
-    ROS_INFO_STREAM("Initializing ranges2 as ROI in scan_buffer_" << roi);
-    cv::Mat ranges2 = cv::Mat(scan_buffer_, roi);
-    ROS_INFO_STREAM("ranges2.shape: " << ranges2.size);
-    ROS_INFO_STREAM("current_ranges.copyTo(ranges2)");
-    current_ranges.copyTo(ranges2);
-    ROS_INFO_STREAM("current_ranges.shape: " << current_ranges.size << ", scan_buffer_.shape: " << scan_buffer_.size);
-    ROS_INFO_STREAM("scan_buffer_.at(" << scan_index_ << ", " << 0 << ") = " << scan_buffer_.at<uint16_t>(scan_index_, 0) << ", scan_in.ranges[0] = " << scan_in.ranges[0]);
+    // auto roi = cv::Rect(scan_index_, 0, scan_in.ranges.size(), 1);
+    // ROS_INFO_STREAM("Initializing ranges2 as ROI in scan_buffer_" << roi);
+    // cv::Mat ranges2 = cv::Mat(scan_buffer_, roi);
+    // ROS_INFO_STREAM("ranges2.shape: " << ranges2.size);
+    // ROS_INFO_STREAM("current_ranges.copyTo(ranges2)");
+    // current_ranges.copyTo(ranges2);
+    // ROS_INFO_STREAM("current_ranges.shape: " << current_ranges.size << ", scan_buffer_.shape: " << scan_buffer_.size);
+    
+    // TODO: Make this much faster without loop
+    for (size_t i = 0; i < scan_in.ranges.size(); i++)
+    {
+      scan_buffer_.at<uint16_t>(scan_index_, i) = (uint16_t)(scan_in.ranges[i] * 1000);
+    }
+    // ROS_INFO_STREAM("scan_buffer_.at(" << scan_index_ << ", " << 0 << ") = " << scan_buffer_.at<uint16_t>(scan_index_, 0) << ", scan_in.ranges[0] = " << scan_in.ranges[0]);
 
     // std::cout << "After  push_back: scan_buffer_: " << std::endl << scan_buffer_ << std::endl;
     // std::cout << "stretched_depth_mat_: " << std::endl << stretched_depth_mat_ << std::endl;

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -158,7 +158,7 @@ public:
     {
       auto vertical_step = abs(current_req_.max_height - current_req_.min_height) / current_req_.vertical_resolution;
       auto horizontal_step = abs(current_req_.max_width - current_req_.min_width) / current_req_.horizontal_resolution;
-      auto depth_step = abs(scan_in.range_max - scan_in.range_min) / std::numeric_limits<ushort>::max();
+      auto range_step = abs(current_req_.max_range - current_req_.min_range) / std::numeric_limits<ushort>::max();
 
       tf::StampedTransform transform;
       tf_->lookupTransform(fixed_frame_id, scan_in.header.frame_id, ros::Time(0), transform);
@@ -166,7 +166,7 @@ public:
       uint row = stretched_range_mat_.rows - ((height - current_req_.min_height) / vertical_step);  // TODO: check proper types, absolutes and rounding
       // ROS_INFO_STREAM("height: " << height << ", max_height: " << current_req_.max_height << ", min_height: " << current_req_.min_height << ", vertical_step: " << vertical_step << ", row: " << row);
       // ROS_INFO_STREAM("max_width: " << current_req_.max_width << ", min_width: " << current_req_.min_width << ", horizontal_step: " << horizontal_step);
-      // ROS_INFO_STREAM("scan_in.range_max: " << scan_in.range_max << ", scan_in.range_min: " << scan_in.range_min << ", std::numeric_limits<short>::max(): " << std::numeric_limits<ushort>::max() << ", depth_step: " << depth_step);
+      // ROS_INFO_STREAM("scan_in.range_max: " << scan_in.range_max << ", scan_in.range_min: " << scan_in.range_min << ", std::numeric_limits<short>::max(): " << std::numeric_limits<ushort>::max() << ", range_step: " << range_step);
 
       for (size_t i = 0; i < scan_in.ranges.size(); i++)
       {
@@ -176,12 +176,19 @@ public:
         // ROS_DEBUG_STREAM("i: " << i << ", row: " << row << ", column: " << column << ", range: " << scan_in.ranges[i]);
         if (column >= 0 && column < stretched_range_mat_.cols && row >= 0 && row < stretched_range_mat_.rows)
         {
-          auto value = (scan_in.ranges[i] - scan_in.range_min) / depth_step;
-          // ROS_DEBUG_STREAM("scan_in.ranges["<<i<<"]: " << scan_in.ranges[i] << ", value: " << value << ", (ushort)value: " << (ushort)value);
-          
-          // If a pixel already has a value (which is always, the case, pixels are initialized to max range), 
-          // take the minimum value of the new and current
-          stretched_range_mat_.at<ushort>(row, column) = std::min((ushort)value, stretched_range_mat_.at<ushort>(row, column));
+          if (scan_in.ranges[i] < current_req_.min_range)
+          {
+            stretched_range_mat_.at<ushort>(row, column) = 0;
+          }
+          else
+          {
+            auto value = (scan_in.ranges[i] - scan_in.range_min) / range_step;
+            // ROS_DEBUG_STREAM("scan_in.ranges["<<i<<"]: " << scan_in.ranges[i] << ", value: " << value << ", (ushort)value: " << (ushort)value);
+
+            // If a pixel already has a value (which is always the case, since pixels are initialized to max range),
+            // take the minimum value of the new and current
+            stretched_range_mat_.at<ushort>(row, column) = std::min((ushort)value, stretched_range_mat_.at<ushort>(row, column));
+          }
         }
         else
         {

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -156,8 +156,10 @@ public:
 
       for (size_t i = 0; i < scan_in.ranges.size(); i++)
       {
-        uint column = i;
-        ROS_DEBUG_STREAM("i: " << i << ", row: " << row << ", column: " << column << ", range: " << scan_in.ranges[i]);
+        auto measurement_angle = scan_in.angle_min + i*scan_in.angle_increment;
+        uint column = (measurement_angle - current_req_.min_width) / horizontal_step;
+        // ROS_DEBUG_STREAM("column: " << column << ", index: " << i << ", measurement_angle: " << measurement_angle << ", max_width: " << current_req_.max_width << ", min_width: " << current_req_.min_width << ", horizontal_step: " << horizontal_step);
+        // ROS_DEBUG_STREAM("i: " << i << ", row: " << row << ", column: " << column << ", range: " << scan_in.ranges[i]);
         if (column >= 0 && column < stretched_range_mat_.cols && row >= 0 && row < stretched_range_mat_.rows)
         {
           auto value = (scan_in.ranges[i] - scan_in.range_min) / depth_scale;

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -169,16 +169,10 @@ public:
     // stretched_range_image_.step = stretched_range_image_.width;
     // stretched_range_image_.data.resize(stretched_range_image_.width * stretched_range_image_.height);
     stretched_range_image_.header.frame_id = fixed_frame_.c_str();
+    ROS_WARN_COND(req.horizontal_resolution == 0, "horizontal_resolution is zero");
+    ROS_WARN_COND(req.vertical_resolution == 0, "vertical_resolution is zero");
     stretched_range_mat_ = cv::Mat::zeros(req.horizontal_resolution, req.vertical_resolution, CV_16UC1);
-    if (stretched_range_mat_.empty())
-    {
-      ROS_INFO("Mat is still empty");
-    }
-    else
-    {
-      ROS_INFO("Mat is filled");
-    }
-    ROS_INFO_STREAM("Created image to be filled by scans:\n" << stretched_range_image_);
+    ROS_DEBUG_STREAM("Created image to be filled by scans:\n" << stretched_range_image_);
 
     subscribe();
     return true;

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -349,19 +349,19 @@ public:
         auto min_value = curr_value > 0 ? std::min(depth_value, curr_value) : depth_value;
         scan_depth_buffer_.at<uint16_t>(scan_index_, depth_column) = min_value;
 
-        ROS_INFO_STREAM_COND(i==i,
-          "i: " << i <<
-          ", height: " << height <<
-          ", range: " << scan_in.ranges[i] <<
-          ", measurement_angle: " << measurement_angle <<
-          ", depth_x_distance: " << depth_x_distance <<
-          ", depth_column: " << depth_column <<
-          ", depth_min_x: " << depth_min_x <<
-          ", depth_horizontal_step: " << depth_horizontal_step <<
-          ", depth: " << depth <<
-          ", depth_value: " << depth_value <<
-          ", min_value: " << min_value <<
-          "");
+        // ROS_INFO_STREAM_COND(i==i,
+        //   "i: " << i <<
+        //   ", height: " << height <<
+        //   ", range: " << scan_in.ranges[i] <<
+        //   ", measurement_angle: " << measurement_angle <<
+        //   ", depth_x_distance: " << depth_x_distance <<
+        //   ", depth_column: " << depth_column <<
+        //   ", depth_min_x: " << depth_min_x <<
+        //   ", depth_horizontal_step: " << depth_horizontal_step <<
+        //   ", depth: " << depth <<
+        //   ", depth_value: " << depth_value <<
+        //   ", min_value: " << min_value <<
+        //   "");
       }
     }
     // ROS_INFO_STREAM("scan_buffer_.at(" << scan_index_ << ", " << 0 << ") = " << scan_buffer_.at<uint16_t>(scan_index_, 0) << ", scan_in.ranges[0] = " << scan_in.ranges[0]);
@@ -511,6 +511,7 @@ public:
     }
     cv::Mat y_map;
     cv::resize(y_map_column, y_map, cv::Size(current_req_.vertical_resolution, current_req_.horizontal_resolution), cv::INTER_NEAREST);
+    std::cout << "y_map" << std::endl << y_map << std::endl;
 
     // Generate x map for use in cv::remap
     ROS_DEBUG("Create x_map_row");
@@ -550,6 +551,8 @@ public:
       // Depths are already in the right column, that is done in ScanToImages where the appropriate trigonometry is perfomed
       x_map_row.at<float>(0, x) = (float)x;
     }
+    std::cout << "depth_x_map_row" << std::endl << depth_x_map_row << std::endl;
+
     cv::Mat depth_x_map;
     cv::resize(depth_x_map_row, depth_x_map, cv::Size(current_req_.vertical_resolution, current_req_.horizontal_resolution), cv::INTER_NEAREST);
     ROS_INFO_STREAM("depth_x_map has size " << depth_x_map.size());

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -323,6 +323,13 @@ public:
     for (size_t i = 0; i < scan_in.ranges.size(); i++)
     {
       scan_range_buffer_.at<uint16_t>(scan_index_, i) = (uint16_t)(scan_in.ranges[i] * 1000);
+
+      auto measurement_angle = scan_in.angle_min + i*scan_in.angle_increment;
+      auto depth_x_distance = (uint16_t)(scan_in.ranges[i] * sin(measurement_angle));
+      uint depth_column = (depth_x_distance - depth_min_x) / depth_horizontal_step;
+
+      auto depth = (scan_in.ranges[i] * cos(measurement_angle));
+      scan_depth_buffer_.at<uint16_t>(scan_index_, depth_column) = (uint16_t)(depth * 1000);
     }
     // ROS_INFO_STREAM("scan_buffer_.at(" << scan_index_ << ", " << 0 << ") = " << scan_buffer_.at<uint16_t>(scan_index_, 0) << ", scan_in.ranges[0] = " << scan_in.ranges[0]);
 
@@ -414,6 +421,7 @@ public:
 
 
     scan_range_buffer_ = cv::Mat::zeros(1000, 1000, CV_16UC1);
+    scan_depth_buffer_ = cv::Mat::zeros(1000, req.horizontal_resolution, CV_16UC1);
     scan_index_ = 0;
     height_values_ = cv::Mat::zeros(1000, 0, CV_64FC1);
 
@@ -522,6 +530,7 @@ private:
   ros::Publisher stretched_depth_image_pub_;
 
   cv::Mat scan_range_buffer_;
+  cv::Mat scan_depth_buffer_;
   uint scan_index_;
   cv::Mat height_values_;
   uint max_scan_length_ = 0;

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -155,7 +155,7 @@ public:
        */
       auto depth_min_x = current_req_.max_range * sin(current_req_.min_width);  // [m] At what X would the max range fall at the first ray in the FoV?
       auto depth_max_x = current_req_.max_range * sin(current_req_.max_width);  // [m] At what X would the max range fall at the last ray in the FoV?
-      ROS_INFO_STREAM("current_req_.max_range: " << current_req_.max_range << ", current_req_.min_width: " << current_req_.min_width << ", sin(current_req_.min_width): " << sin(current_req_.min_width));
+      // ROS_INFO_STREAM("current_req_.max_range: " << current_req_.max_range << ", current_req_.min_width: " << current_req_.min_width << ", sin(current_req_.min_width): " << sin(current_req_.min_width));
       auto depth_width_x = abs(depth_max_x - depth_min_x);  // [m] Width of the image in meters
       auto depth_max_val = current_req_.max_range;  // [m]Maximum depth represented in the depth image
 
@@ -170,7 +170,7 @@ public:
       // ROS_INFO_STREAM("height: " << height << ", max_height: " << current_req_.max_height << ", min_height: " << current_req_.min_height << ", vertical_step: " << vertical_step << ", row: " << row);
       // ROS_INFO_STREAM("max_width: " << current_req_.max_width << ", min_width: " << current_req_.min_width << ", horizontal_step: " << horizontal_step);
       // ROS_INFO_STREAM("scan_in.range_max: " << scan_in.range_max << ", scan_in.range_min: " << scan_in.range_min << ", std::numeric_limits<short>::max(): " << std::numeric_limits<uint16_t>::max());
-      ROS_INFO_STREAM("depth_min_x: " << depth_min_x << ", depth_max_x: " << depth_max_x << ", depth_width_x: " << depth_width_x << ", depth_max_val: " << depth_max_val << ", depth_horizontal_step: " << depth_horizontal_step);
+      // ROS_INFO_STREAM("depth_min_x: " << depth_min_x << ", depth_max_x: " << depth_max_x << ", depth_width_x: " << depth_width_x << ", depth_max_val: " << depth_max_val << ", depth_horizontal_step: " << depth_horizontal_step);
 
       for (size_t i = 0; i < scan_in.ranges.size(); i++)
       {
@@ -182,7 +182,7 @@ public:
         uint range_column = (measurement_angle - current_req_.min_width) / range_horizontal_step;
         uint depth_column = (depth_x_distance - depth_min_x) / depth_horizontal_step;
         // ROS_DEBUG_STREAM("column: " << column << ", index: " << i << ", measurement_angle: " << measurement_angle << ", max_width: " << current_req_.max_width << ", min_width: " << current_req_.min_width << ", horizontal_step: " << horizontal_step);
-        ROS_INFO_STREAM_COND(i==i, "i: " << i << ", row: " << row << ", range_column: " << range_column << ", range: " << range << ", depth_column: " << depth_column);
+        // ROS_INFO_STREAM("i: " << i << ", row: " << row << ", range_column: " << range_column << ", range: " << range << ", depth_column: " << depth_column);
         if (range_column >= 0 && range_column < stretched_range_mat_.cols && row >= 0 && row < stretched_range_mat_.rows)
         {
           if (range < current_req_.min_range)
@@ -210,7 +210,7 @@ public:
           if (depth > 0.0) // Negative values are possible if the FoV is more than 180 degrees and the laser measures behind it's center plane
           {
             auto depth_value = depth * 1000;  // +1 value means 1mm further away
-            ROS_INFO_STREAM_COND(i==i, "scan_in.ranges["<<i<<"] ("<< measurement_angle << " rad): range: " << range << ", depth: " << depth << ", (uint16_t)depth_value: " << (uint16_t)depth_value << ", depth_column: " << depth_column);
+            // ROS_INFO_STREAM("scan_in.ranges["<<i<<"] ("<< measurement_angle << " rad): range: " << range << ", depth: " << depth << ", (uint16_t)depth_value: " << (uint16_t)depth_value << ", depth_column: " << depth_column);
             stretched_depth_mat_.at<uint16_t>(row, depth_column) = (uint16_t)depth_value;
           }
         }
@@ -295,8 +295,8 @@ public:
 
     scan_hist_mutex_.unlock();
 
-    std::cout << "stretched_range_mat_: " << std::endl << stretched_range_mat_ << std::endl;
-    std::cout << "stretched_depth_mat_: " << std::endl << stretched_depth_mat_ << std::endl;
+    // std::cout << "stretched_range_mat_: " << std::endl << stretched_range_mat_ << std::endl;
+    // std::cout << "stretched_depth_mat_: " << std::endl << stretched_depth_mat_ << std::endl;
 
     cv_bridge::CvImage cvi_range_mat;
     cvi_range_mat.encoding = sensor_msgs::image_encodings::TYPE_16UC1;

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -241,21 +241,24 @@ public:
     // ROS_INFO_STREAM("height_values_.size: " << height_values_.size);
     // std::cout << "Before push_back: scan_buffer_: " << std::endl << scan_buffer_ << std::endl;
 
-    // std::vector<uint16_t> converted_ranges(scan_in.ranges.begin(), scan_in.ranges.end());
+    // std::vector<float> ranges(scan_in.ranges.begin(), scan_in.ranges.end());
 
     // ROS_INFO_STREAM("Initializing current_ranges from converted_ranges");
-    // cv::Mat current_ranges = cv::Mat(converted_ranges, true);
-    // ROS_INFO_STREAM("current_ranges *= 1000");
-    // current_ranges *= 1000;  // From meters to millimeters
-    // // std::cout << "current_ranges = " << current_ranges << std::endl;
+    // cv::Mat ranges_mat = cv::Mat(ranges, true);
+    // ranges_mat *= 1000;  // From meters to millimeters
+    // cv::Mat ranges_as_uint16;
+    // ranges_mat.convertTo(ranges_as_uint16, CV_16UC1);
+    // // ROS_INFO_STREAM("ranges_mat *= 1000");
+    // std::cout << "ranges_as_uint16 = " << ranges_as_uint16.t() << std::endl;
 
-    // auto roi = cv::Rect(scan_index_, 0, scan_in.ranges.size(), 1);
-    // ROS_INFO_STREAM("Initializing ranges2 as ROI in scan_buffer_" << roi);
-    // cv::Mat ranges2 = cv::Mat(scan_buffer_, roi);
+    // auto roi = cv::Rect(0, scan_index_, scan_in.ranges.size(), 1);
+    // ROS_INFO_STREAM("Initializing ranges2 as ROI in scan_range_buffer_" << roi);
+    // cv::Mat ranges2 = cv::Mat(scan_range_buffer_, roi);
     // ROS_INFO_STREAM("ranges2.shape: " << ranges2.size);
-    // ROS_INFO_STREAM("current_ranges.copyTo(ranges2)");
-    // current_ranges.copyTo(ranges2);
-    // ROS_INFO_STREAM("current_ranges.shape: " << current_ranges.size << ", scan_buffer_.shape: " << scan_buffer_.size);
+    // ROS_INFO_STREAM("ranges_as_uint16.copyTo(ranges2)");
+    // ranges_as_uint16.copyTo(ranges2);
+    // ROS_INFO_STREAM("ranges_as_uint16.shape: " << ranges_as_uint16.size << ", scan_buffer_.shape: " << scan_range_buffer_.size);
+    // std::cout << "ranges2 = " << ranges2.t() << std::endl;
     
     // TODO: Make this much faster without loop
     for (size_t i = 0; i < scan_in.ranges.size(); i++)

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -270,6 +270,11 @@ public:
     stretched_depth_mat_ = cv::Mat::zeros(req.vertical_resolution, req.horizontal_resolution, CV_16UC1);
     ROS_DEBUG_STREAM("Created image to be filled by scans:\n" << stretched_depth_image_);
 
+
+    scan_buffer_ = cv::Mat::zeros(1000, 1000, CV_16UC1);
+    scan_index_ = 0;
+    height_values_ = cv::Mat::zeros(1000, 0, CV_16UC1);
+
     subscribe();
     return true;
   }
@@ -302,7 +307,7 @@ public:
 
     cv_bridge::CvImage cvi_range_mat;
     cvi_range_mat.encoding = sensor_msgs::image_encodings::TYPE_16UC1;
-    cvi_range_mat.image = stretched_range_mat_;
+    cvi_range_mat.image = scan_buffer_;
     cvi_range_mat.toImageMsg(stretched_range_image_);
     stretched_range_image_.header.stamp = ros::Time::now();
     stretched_range_image_.header.frame_id = fixed_frame_.c_str();
@@ -336,6 +341,10 @@ private:
   ros::Publisher pointcloud2_pub_;
   ros::Publisher stretched_range_image_pub_;
   ros::Publisher stretched_depth_image_pub_;
+
+  cv::Mat scan_buffer_;
+  uint scan_index_;
+  cv::Mat height_values_;
 
   cv::Mat stretched_range_mat_;
   sensor_msgs::Image stretched_range_image_;

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -322,7 +322,7 @@ public:
     // TODO: Make this much faster without loop
     for (size_t i = 0; i < scan_in.ranges.size(); i++)
     {
-      scan_buffer_.at<uint16_t>(scan_index_, i) = (uint16_t)(scan_in.ranges[i] * 1000);
+      scan_range_buffer_.at<uint16_t>(scan_index_, i) = (uint16_t)(scan_in.ranges[i] * 1000);
     }
     // ROS_INFO_STREAM("scan_buffer_.at(" << scan_index_ << ", " << 0 << ") = " << scan_buffer_.at<uint16_t>(scan_index_, 0) << ", scan_in.ranges[0] = " << scan_in.ranges[0]);
 
@@ -365,7 +365,7 @@ public:
       ScanToImages(fixed_frame_id, scan_in);
     }
 
-    if (!scan_buffer_.empty())
+    if (!scan_range_buffer_.empty())
     {
     }
 
@@ -413,7 +413,7 @@ public:
     ROS_DEBUG_STREAM("Created image to be filled by scans:\n" << stretched_depth_image_);
 
 
-    scan_buffer_ = cv::Mat::zeros(1000, 1000, CV_16UC1);
+    scan_range_buffer_ = cv::Mat::zeros(1000, 1000, CV_16UC1);
     scan_index_ = 0;
     height_values_ = cv::Mat::zeros(1000, 0, CV_64FC1);
 
@@ -452,8 +452,8 @@ public:
     cv_bridge::CvImage cvi_range_mat;
     cvi_range_mat.encoding = sensor_msgs::image_encodings::TYPE_16UC1;
     auto filled_roi = cv::Rect(0, 0, max_scan_length_, scan_index_);
-    ROS_DEBUG_STREAM("Buffer has size " << scan_buffer_.size() << "and the filled region of that has size " << filled_roi);
-    cv::Mat cropped = cv::Mat(scan_buffer_, filled_roi);
+    ROS_DEBUG_STREAM("Buffer has size " << scan_range_buffer_.size() << "and the filled region of that has size " << filled_roi);
+    cv::Mat cropped = cv::Mat(scan_range_buffer_, filled_roi);
     cv::Mat sorted = sortMatRowBy(height_values_, cropped, sorted_heights);
 
     // Generate y_map for use in cv::remap
@@ -494,7 +494,7 @@ public:
 
     cv_bridge::CvImage cvi_depth_mat;
     cvi_depth_mat.encoding = sensor_msgs::image_encodings::TYPE_16UC1;
-    cvi_depth_mat.image = stretched_depth_mat_;
+    cvi_depth_mat.image = scan_depth_buffer_;
     cvi_depth_mat.toImageMsg(stretched_depth_image_);
     stretched_depth_image_.header.stamp = ros::Time::now();
     stretched_depth_image_.header.frame_id = fixed_frame_.c_str();
@@ -521,7 +521,7 @@ private:
   ros::Publisher stretched_range_image_pub_;
   ros::Publisher stretched_depth_image_pub_;
 
-  cv::Mat scan_buffer_;
+  cv::Mat scan_range_buffer_;
   uint scan_index_;
   cv::Mat height_values_;
   uint max_scan_length_ = 0;

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -123,9 +123,11 @@ public:
      * X distance over the plane is then $range * cos(angle)$
      * Depth to the plane is then $range * sin(angle)$
      *
-     * The image X dimension is dependent on max range & angle, since $X_max = range_max * cos(angle_max)$
+     * The image X dimension is dependent on max range & FoV max angle, since $X_max = range_max * cos(angle_max)$
      *
      */
+    auto max_x = current_req_.max_range * cos(current_req_.max_width);
+    auto min_x = current_req_.max_range * cos(current_req_.min_width);
   }
 
   unsigned int GetPointsInScan(const sensor_msgs::LaserScan& scan)

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -257,57 +257,6 @@ public:
 
     double previous_range = 0;
     uint previous_range_column = -1;
-
-    // for (size_t i = 0; i < scan_in.ranges.size(); i++)
-    // {
-    //   auto range = scan_in.ranges[i];
-    //   auto measurement_angle = scan_in.angle_min + i*scan_in.angle_increment;
-
-    //   auto depth_x_distance = range * sin(measurement_angle);
-
-    //   uint range_column = (measurement_angle - current_req_.min_width) / range_horizontal_step;
-    //   uint depth_column = (depth_x_distance - depth_min_x) / depth_horizontal_step;
-    //   // ROS_DEBUG_STREAM("column: " << column << ", index: " << i << ", measurement_angle: " << measurement_angle << ", max_width: " << current_req_.max_width << ", min_width: " << current_req_.min_width << ", horizontal_step: " << horizontal_step);
-    //   // ROS_INFO_STREAM("i: " << i << ", row: " << row << ", range_column: " << range_column << ", range: " << range << ", depth_column: " << depth_column);
-    //   if (range_column >= 0 && range_column < stretched_range_mat_.cols && row >= 0 && row < stretched_range_mat_.rows)
-    //   {
-    //     if (range < current_req_.min_range)
-    //     {
-    //       stretched_range_mat_.at<uint16_t>(row, range_column) = 0;
-    //     }
-    //     else
-    //     {
-    //       auto range_value = range * 1000;  // +1 value means 1mm further away
-    //       // ROS_DEBUG_STREAM("scan_in.ranges["<<i<<"]: " << range << ", value: " << value << ", (uint16_t)value: " << (uint16_t)value);
-
-    //       // If a pixel already has a value (which is always the case, since pixels are initialized to max range),
-    //       // take the minimum value of the new and current
-    //       stretched_range_mat_.at<uint16_t>(row, range_column) = (uint16_t)range_value;
-    //     }
-    //   }
-    //   else
-    //   {
-    //     ROS_DEBUG("Row and/or column outside of range image");
-    //   }
-    //   previous_range = range;
-    //   previous_range_column = range_column;
-
-
-    //   if (depth_column >= 0 && depth_column < stretched_depth_mat_.cols && row >= 0 && row < stretched_depth_mat_.rows)
-    //   {
-    //     auto depth = (range * cos(measurement_angle));
-    //     if (depth > 0.0) // Negative values are possible if the FoV is more than 180 degrees and the laser measures behind it's center plane
-    //     {
-    //       auto depth_value = depth * 1000;  // +1 value means 1mm further away
-    //       // ROS_INFO_STREAM("scan_in.ranges["<<i<<"] ("<< measurement_angle << " rad): range: " << range << ", depth: " << depth << ", (uint16_t)depth_value: " << (uint16_t)depth_value << ", depth_column: " << depth_column);
-    //       stretched_depth_mat_.at<uint16_t>(row, depth_column) = (uint16_t)depth_value;
-    //     }
-    //   }
-    //   else
-    //   {
-    //     ROS_DEBUG("Row and/or column outside of depth image");
-    //   }
-    // }
   
     // New implementation that also does interpolation
     // ROS_INFO_STREAM("Current height: " << height << ", current index: " << scan_index_);

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -149,7 +149,7 @@ public:
       auto height = transform.getOrigin().z();
       auto vertical_step = (current_req_.max_height - current_req_.min_height) / current_req_.vertical_resolution;
 
-      uint row = (height - current_req_.min_height) / vertical_step;  // TODO: check proper types, absolutes and rounding
+      uint row = stretched_range_mat_.rows - ((height - current_req_.min_height) / vertical_step);  // TODO: check proper types, absolutes and rounding
       ROS_INFO_STREAM("height: " << height << ", max_height: " << current_req_.max_height << ", min_height: " << current_req_.min_height << ", vertical_step: " << vertical_step << ", row: " << row);
       auto depth_scale = (scan_in.range_max - scan_in.range_min) / std::numeric_limits<short>::max();
 

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -153,6 +153,15 @@ public:
       skew_scan_sub_.shutdown();
     }
     ROS_INFO("Stopped listening to scans");
+
+    scan_hist_mutex_.lock();
+
+    sensor_msgs::PointCloud cloud;
+    assembleScanIndices(cloud, 0, scan_hist_.size());
+    ROS_INFO_STREAM_NAMED("stopCollectionAndAssembleScans2", "Cloud has " << cloud.points.size() << " points from " << scan_hist_.size() << " scans");
+
+    scan_hist_mutex_.unlock();
+
     return true;
   }
 

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -45,6 +45,7 @@
 #include "opencv2/imgproc/imgproc.hpp"
 #include "cv_bridge/cv_bridge.h"
 #include "tf/transform_datatypes.h"
+#include <limits>
 
 using namespace laser_geometry;
 using namespace std ;
@@ -150,6 +151,7 @@ public:
 
       uint row = (height - current_req_.min_height) / vertical_step;  // TODO: check proper types, absolutes and rounding
       ROS_INFO_STREAM("height: " << height << ", max_height: " << current_req_.max_height << ", min_height: " << current_req_.min_height << ", vertical_step: " << vertical_step << ", row: " << row);
+      auto depth_scale = (scan_in.range_max - scan_in.range_min) / std::numeric_limits<short>::max();
 
       for (size_t i = 0; i < scan_in.ranges.size(); i++)
       {
@@ -157,7 +159,7 @@ public:
         ROS_DEBUG_STREAM("i: " << i << ", row: " << row << ", column: " << column << ", range: " << scan_in.ranges[i]);
         if (column >= 0 && column < stretched_range_mat_.cols && row >= 0 && row < stretched_range_mat_.rows)
         {
-          stretched_range_mat_.at<ushort>(row, column) = 65535;//(ushort)(scan_in.ranges[i]*1000);  // TODO: scale according to current_req_.depth_resolution
+          stretched_range_mat_.at<ushort>(row, column) = (ushort)(scan_in.ranges[i] - scan_in.range_min) / depth_scale;  // TODO: scale according to current_req_.depth_resolution
         }
         else
         {

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -144,7 +144,7 @@ public:
 
     tf::StampedTransform transform;
     tf_->lookupTransform(fixed_frame_id, scan_in.header.frame_id, ros::Time(0), transform);
-    auto height = transform.getOrigin().z(); // TODO: Make this bit configurable to be generic
+    auto height = (double)transform.getOrigin().z(); // TODO: Make this bit configurable to be generic
     uint row = stretched_range_mat_.rows - ((height - current_req_.min_height) / vertical_step);  // TODO: check proper types, absolutes and rounding
     // ROS_INFO_STREAM("height: " << height << ", max_height: " << current_req_.max_height << ", min_height: " << current_req_.min_height << ", vertical_step: " << vertical_step << ", row: " << row);
     // ROS_INFO_STREAM("max_width: " << current_req_.max_width << ", min_width: " << current_req_.min_width << ", horizontal_step: " << horizontal_step);
@@ -206,8 +206,9 @@ public:
     // }
   
     // New implementation that also does interpolation
-    ROS_INFO_STREAM("Current height: " << height << ", current index: " << scan_index_);
-    height_values_.push_back(height);
+    // ROS_INFO_STREAM("Current height: " << height << ", current index: " << scan_index_);
+    height_values_.push_back<double>(height);
+    ROS_INFO_STREAM("height_values_.size: " << height_values_.size);
     // std::cout << "Before push_back: scan_buffer_: " << std::endl << scan_buffer_ << std::endl;
 
     // std::vector<uint16_t> converted_ranges(scan_in.ranges.begin(), scan_in.ranges.end());
@@ -316,7 +317,7 @@ public:
 
     scan_buffer_ = cv::Mat::zeros(1000, 1000, CV_16UC1);
     scan_index_ = 0;
-    height_values_ = cv::Mat::zeros(1000, 0, CV_16UC1);
+    height_values_ = cv::Mat::zeros(1000, 0, CV_64FC1);
 
     subscribe();
     return true;

--- a/srv/StartCollection.srv
+++ b/srv/StartCollection.srv
@@ -1,0 +1,10 @@
+float32 min_height  # [m]
+float32 max_height  # [m]
+float32 min_width  # [rad]
+float32 max_width  # [rad]
+float32 vertical_resolution  # [m]
+float32 horizontal_resolution  # [rad]
+float32 depth_resolution  # [m]
+---
+bool success
+string message

--- a/srv/StartCollection.srv
+++ b/srv/StartCollection.srv
@@ -2,9 +2,11 @@ float32 min_height  # [m]
 float32 max_height  # [m]
 float32 min_width  # [rad]
 float32 max_width  # [rad]
-float32 vertical_resolution  # [m]
-float32 horizontal_resolution  # [rad]
-float32 depth_resolution  # [m]
+float32 min_range  # [m]
+float32 max_range  # [m]
+int32 vertical_resolution  # pixels
+int32 horizontal_resolution  # pixels
+# int32 depth_resolution  Defined by pixel depth, hardcoded to 16 bits
 ---
 bool success
 string message

--- a/srv/StartCollection.srv
+++ b/srv/StartCollection.srv
@@ -2,8 +2,6 @@ float32 min_height  # [m]
 float32 max_height  # [m]
 float32 min_width  # [rad]
 float32 max_width  # [rad]
-float32 min_range  # [m]
-float32 max_range  # [m]
 int32 vertical_resolution  # pixels
 int32 horizontal_resolution  # pixels
 # int32 depth_resolution  Defined by pixel depth, hardcoded to 16 bits

--- a/srv/StopCollectionAndAssembleScans2.srv
+++ b/srv/StopCollectionAndAssembleScans2.srv
@@ -1,0 +1,3 @@
+---
+bool success
+string message

--- a/test/dummy_scan_producer.cpp
+++ b/test/dummy_scan_producer.cpp
@@ -42,6 +42,9 @@
 #include <ros/ros.h>
 #include <tf/transform_broadcaster.h>
 #include <sensor_msgs/LaserScan.h>
+#include <algorithm>
+
+using namespace std ;
 
 void runLoop()
 {
@@ -106,6 +109,7 @@ void runLoop()
         // scan.intensities[i] = 10.0;
       }
       scan.ranges[i] *= -z * 0.5;
+      scan.ranges[i] = scan.ranges[i] < 0 ? 0 : scan.ranges[i];
     }
 
     scan_pub.publish(scan);

--- a/test/dummy_scan_producer.cpp
+++ b/test/dummy_scan_producer.cpp
@@ -105,7 +105,7 @@ void runLoop()
         scan.ranges[i] = intercept / (slope * cos(angle) - sin(angle));
         // scan.intensities[i] = 10.0;
       }
-      // scan.ranges[i] *= -z * 0.5;
+      scan.ranges[i] *= -z * 0.5;
     }
 
     scan_pub.publish(scan);

--- a/test/dummy_scan_producer.cpp
+++ b/test/dummy_scan_producer.cpp
@@ -69,23 +69,30 @@ void runLoop()
   scan.ranges.resize(N);
   // scan.intensities.resize(N);
 
-  for (unsigned int i=0; i<N; i++)
-  {
-    scan.ranges[i] = 1.0;
-    // scan.intensities[i] = 10.0;
-  }
-
   int direction = 1;
 
   // Keep sending scans until the assembler is done
   while (nh.ok())
   {
+    for (unsigned int i=0; i<N; i++)
+    {
+      auto angle = scan.angle_min + i*scan.angle_increment - 1.571;
+
+      auto m = 1; // slope
+      auto b = 1; // Intercept of y axis
+      // y = mx + b
+      // x = r * cos(angle)
+      // r = b / (m * cos(a) - sin(a))
+      scan.ranges[i] = b / (m * cos(angle) - sin(angle));
+      // scan.intensities[i] = 10.0;
+    }
+
     laser_transform.getOrigin().setZ(laser_transform.getOrigin().getZ() - (0.025 * direction));
     scan.header.stamp = ros::Time::now();
     scan_pub.publish(scan);
     broadcaster.sendTransform(tf::StampedTransform(laser_transform, scan.header.stamp, "dummy_laser_link", "dummy_base_link"));
     loop_rate.sleep();
-    ROS_INFO_STREAM("Publishing scan at z=" << laser_transform.getOrigin().getZ());
+    ROS_DEBUG_STREAM("Publishing scan at z=" << laser_transform.getOrigin().getZ());
 
     if(laser_transform.getOrigin().getZ() < -2.0 || laser_transform.getOrigin().getZ() > 0)
     {

--- a/test/dummy_scan_producer.cpp
+++ b/test/dummy_scan_producer.cpp
@@ -48,7 +48,7 @@ void runLoop()
   ros::NodeHandle nh;
 
   ros::Publisher scan_pub   = nh.advertise<sensor_msgs::LaserScan>("dummy_scan", 100);
-  ros::Rate loop_rate(5);
+  ros::Rate loop_rate(10);
 
   // Configure the Transform broadcaster
   tf::TransformBroadcaster broadcaster;
@@ -56,33 +56,41 @@ void runLoop()
 
   // Populate the dummy laser scan
   sensor_msgs::LaserScan scan;
-  scan.header.frame_id = "/dummy_laser_link";
-  scan.angle_min = 0.0;
-  scan.angle_max = 99.0;
-  scan.angle_increment = 1.0;
+  scan.header.frame_id = "dummy_laser_link";
+
+  const unsigned int N = 100;
+  scan.angle_min = -2;
+  scan.angle_max = 2;
+  scan.angle_increment = 0.04;
   scan.time_increment = .001;
   scan.scan_time = .05;
   scan.range_min = .01;
   scan.range_max = 100.0;
-
-  const unsigned int N = 100;
   scan.ranges.resize(N);
-  scan.intensities.resize(N);
+  // scan.intensities.resize(N);
 
   for (unsigned int i=0; i<N; i++)
   {
-    scan.ranges[i] = 10.0;
-    scan.intensities[i] = 10.0;
+    scan.ranges[i] = 1.0;
+    // scan.intensities[i] = 10.0;
   }
+
+  int direction = 1;
 
   // Keep sending scans until the assembler is done
   while (nh.ok())
   {
+    laser_transform.getOrigin().setZ(laser_transform.getOrigin().getZ() - (0.025 * direction));
     scan.header.stamp = ros::Time::now();
     scan_pub.publish(scan);
     broadcaster.sendTransform(tf::StampedTransform(laser_transform, scan.header.stamp, "dummy_laser_link", "dummy_base_link"));
     loop_rate.sleep();
-    ROS_INFO("Publishing scan");
+    ROS_INFO_STREAM("Publishing scan at z=" << laser_transform.getOrigin().getZ());
+
+    if(laser_transform.getOrigin().getZ() < -2.0 || laser_transform.getOrigin().getZ() > 0)
+    {
+      direction *= -1;
+    }
   }
 }
 

--- a/test/dummy_scan_producer.cpp
+++ b/test/dummy_scan_producer.cpp
@@ -75,6 +75,11 @@ void runLoop()
   // Keep sending scans until the assembler is done
   while (nh.ok())
   {
+    auto z = laser_transform.getOrigin().getZ() - (0.025 * direction);
+    laser_transform.getOrigin().setZ(z);
+
+    scan.header.stamp = ros::Time::now();
+
     for (unsigned int i=0; i<N; i++)
     {
       auto angle = scan.angle_min + i*scan.angle_increment - 1.571;
@@ -100,10 +105,9 @@ void runLoop()
         scan.ranges[i] = intercept / (slope * cos(angle) - sin(angle));
         // scan.intensities[i] = 10.0;
       }
+      scan.ranges[i] *= -z * 0.5;
     }
 
-    laser_transform.getOrigin().setZ(laser_transform.getOrigin().getZ() - (0.025 * direction));
-    scan.header.stamp = ros::Time::now();
     scan_pub.publish(scan);
     broadcaster.sendTransform(tf::StampedTransform(laser_transform, scan.header.stamp, "dummy_laser_link", "dummy_base_link"));
     loop_rate.sleep();

--- a/test/dummy_scan_producer.cpp
+++ b/test/dummy_scan_producer.cpp
@@ -105,7 +105,7 @@ void runLoop()
         scan.ranges[i] = intercept / (slope * cos(angle) - sin(angle));
         // scan.intensities[i] = 10.0;
       }
-      scan.ranges[i] *= -z * 0.5;
+      // scan.ranges[i] *= -z * 0.5;
     }
 
     scan_pub.publish(scan);


### PR DESCRIPTION
Implements https://github.com/mojin-robotics/cob4/issues/2288

### TODO
- [x] Calculate & publish proper `sensor_msgs/PointCloud2` on topic: depth ()
- [x] Calculate & publish proper `sensor_msgs/Image`, 16bit single channel, on topic `depth_image`
- [x] Include test script that is now in https://github.com/mojin-robotics/mojin_perception/pull/86
- [x] If there are more values for the same the same pixel, use the lowest value
- [x] Output a depth image as well
- [x] Interpolate missing pixels in stretched range image (and maybe choose interpolation mode in service request: none, linear, ...)
- [ ] Optimisations for speed :point_right: https://github.com/mojin-robotics/cob4/issues/2477
- [ ] Generalize how to get the height and how that is tightly coupled to selecting a row etc. :point_right: https://github.com/mojin-robotics/cob4/issues/2481
- [ ] ~~See how we can use upstream as much as possible~~ (See https://github.com/mojin-robotics/laser_assembler/pull/1#issuecomment-1148523084)
- [ ] Calculate & publish proper `sensor_msgs/CameraInfo` on topic `camera_info` :point_right: https://github.com/mojin-robotics/cob4/issues/2479
- [ ] Include in bringup and config for `afi-l15` :point_right: https://github.com/mojin-robotics/cob4/issues/2480

